### PR TITLE
Add RPC handling and improve Augmentation

### DIFF
--- a/pkg/yang/camelcase.go
+++ b/pkg/yang/camelcase.go
@@ -36,12 +36,18 @@ func isASCIIDigit(c byte) bool {
 // lowercases names, it's extremely unlikely to have two fields with different
 // capitalizations.  In short, _my_field_name_2 becomes XMyFieldName_2.
 func CamelCase(s string) string {
+	fix := func (c byte) byte {
+		if c == '/' || c == '-' || c == ':' {
+			return '_'
+		}
+		return c
+	}
 	if s == "" {
 		return ""
 	}
 	t := make([]byte, 0, 32)
 	i := 0
-	if s[0] == '_' || s[0] == '-' {
+	if fix(s[0]) == '_' {
 		// Need a capital letter; drop the '_'.
 		t = append(t, 'X')
 		i++
@@ -51,10 +57,7 @@ func CamelCase(s string) string {
 	// That is, we process a word at a time, where words are marked by _ or
 	// upper case letter. Digits are treated as words.
 	for ; i < len(s); i++ {
-		c := s[i]
-		if c == '-' {
-			c = '_'
-		}
+		c := fix(s[i])
 		if c == '_' && i+1 < len(s) && isASCIILower(s[i+1]) {
 			continue // Skip the underscore in s.
 		}

--- a/pkg/yang/camelcase_test.go
+++ b/pkg/yang/camelcase_test.go
@@ -26,6 +26,7 @@ func TestCamelCase(t *testing.T) {
 		{"one_two", "OneTwo"},
 		{"_my_field_name_2", "XMyFieldName_2"},
 		{"Something_Capped", "Something_Capped"},
+		{"/foo/bar", "XFooBar"},
 		{"my_Name", "My_Name"},
 		{"OneTwo", "OneTwo"},
 		{"_", "X"},

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -837,5 +837,5 @@ func errorSort(errors []error) []error {
                 errors[i] = err.err
                 i++
         }
-	return errors
+	return errors[:i]
 }

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -81,14 +81,29 @@ type Entry struct {
 
 	// Fields associated with leaf nodes
 	Type *YangType
-	Exts []*Entry // extensions found
-
-	// Fields associted with choice statements
-	Choice *Entry // The choice statement the entry is part of
-	Case   *Entry // The case statement, if any, the entry is in
+	Exts []*Statement // extensions found
 
 	// Fields associated with list nodes (both lists and leaf-lists)
 	ListAttr *ListAttr
+
+	RPC *RPCEntry // set if we are an RPC
+
+	Augments []*Entry // Augments associated with this entry
+}
+
+// An RPCEntry contains information related to an RPC Node.
+type RPCEntry struct {
+	Input  *Entry
+	Output *Entry
+}
+
+// Modules returns the Modules structure that e is part of.  This is needed
+// when looking for rooted nodes not part of this Entry tree.
+func (e *Entry) Modules() *Modules {
+	for e.Parent != nil {
+		e = e.Parent
+	}
+	return e.Node.(*Module).modules
 }
 
 // A ListAttr is associated with an Entry that represents a List node
@@ -219,14 +234,13 @@ func (e *Entry) importErrors(c *Entry) {
 	for _, err := range c.Errors {
 		e.addError(err)
 	}
-	for _, ce := range e.Exts {
-		e.importErrors(ce)
-	}
+	// TODO(borman): need to determine if the extensions have errors
+	// for _, ce := range e.Exts {
+	// 	e.importErrors(ce)
+	// }
 	for _, ce := range c.Dir {
 		e.importErrors(ce)
 	}
-	e.importErrors(e.Choice)
-	e.importErrors(e.Case)
 }
 
 // checkErrors calls f on every error found in the tree e and its children.
@@ -240,11 +254,10 @@ func (e *Entry) checkErrors(f func(error)) {
 	for _, err := range e.Errors {
 		f(err)
 	}
-	for _, e := range e.Exts {
-		e.checkErrors(f)
-	}
-	e.Choice.checkErrors(f)
-	e.Case.checkErrors(f)
+	// TODO(borman): need to determine if the extensions have errors
+	// for _, e := range e.Exts {
+	// 	e.checkErrors(f)
+	// }
 }
 
 // GetErrors returns a sorted list of errors found in e.
@@ -309,7 +322,14 @@ func ToEntry(n Node) (e *Entry) {
 		entryCache[n] = e
 	}()
 
-	// TODO(borman): should have a defer to process extensions at this point
+	// Copy in the extensions from our Node, if any.
+	defer func(n Node) {
+		if e != nil {
+			for _, ext := range n.Exts() {
+				e.Exts = append(e.Exts, ext)
+			}
+		}
+	}(n)
 
 	// configValue return TSTrue if i contains the value of true, TSFalse
 	// if it contains the value of false, and TSUnset if i does not have
@@ -385,9 +405,10 @@ func ToEntry(n Node) (e *Entry) {
 
 	e = newDirectory(n)
 
-	// Special handling of lists.  The difference between a List
-	// and any other node is that a List has the ListAttr field set.
-	// Other than that it can be processed just like any other Node.
+	// Special handling for individual Node types.  Lists are like any other
+	// node except a List has a ListAttr.
+	//
+	// Nodes of identified special kinds have their Kind set here.
 	switch s := n.(type) {
 	case *List:
 		e.ListAttr = &ListAttr{
@@ -395,6 +416,18 @@ func ToEntry(n Node) (e *Entry) {
 			MaxElements: s.MaxElements,
 			OrderedBy:   s.OrderedBy,
 		}
+	case *Choice:
+		e.Kind = ChoiceEntry
+	case *Case:
+		e.Kind = CaseEntry
+	case *AnyXML:
+		e.Kind = AnyXMLEntry
+	case *Input:
+		e.Kind = InputEntry
+	case *Output:
+		e.Kind = OutputEntry
+	case *Notification:
+		e.Kind = NotificationEntry
 	}
 
 	// Use Elem to get the Value of structure that n is pointing to, not
@@ -402,10 +435,6 @@ func ToEntry(n Node) (e *Entry) {
 	v := reflect.ValueOf(n).Elem()
 	t := v.Type()
 	found := false
-
-	// Collect all the augment entries and apply them after the tree
-	// is fully read in.
-	var augments []*Entry
 
 	for i := t.NumField() - 1; i > 0; i-- {
 		f := t.Field(i)
@@ -416,8 +445,8 @@ func ToEntry(n Node) (e *Entry) {
 		fv := v.Field(i)
 		name := strings.Split(yang, ",")[0]
 		switch name {
-		default:
-			continue
+		case "":
+			e.addError(fmt.Errorf("%s: nil statement", Source(n)))
 		case "config":
 			e.Config, err = configValue(fv.Interface())
 			e.addError(err)
@@ -433,7 +462,7 @@ func ToEntry(n Node) (e *Entry) {
 			for _, a := range fv.Interface().([]*Augment) {
 				ne := ToEntry(a)
 				ne.Parent = e
-				augments = append(augments, ne)
+				e.Augments = append(e.Augments, ne)
 			}
 		case "anyxml":
 			for _, a := range fv.Interface().([]*AnyXML) {
@@ -488,6 +517,28 @@ func ToEntry(n Node) (e *Entry) {
 			// TODO(borman): what do we do with these?
 			// seems fine to ignore them for now, we are
 			// just interested in the tree structure.
+			for _, r := range fv.Interface().([]*RPC) {
+				e.add(r.Name, ToEntry(r))
+			}
+
+		case "input":
+			if i := fv.Interface().(*Input); i != nil {
+				if e.RPC == nil {
+					e.RPC = &RPCEntry{}
+				}
+				e.RPC.Input = ToEntry(i)
+				e.RPC.Input.Name = "input"
+				e.RPC.Input.Kind = InputEntry
+			}
+		case "output":
+			if o := fv.Interface().(*Output); o != nil {
+				if e.RPC == nil {
+					e.RPC = &RPCEntry{}
+				}
+				e.RPC.Output = ToEntry(o)
+				e.RPC.Output.Name = "output"
+				e.RPC.Output.Kind = OutputEntry
+			}
 		case "uses":
 			for _, a := range fv.Interface().([]*Uses) {
 				e.merge(nil, ToEntry(a))
@@ -496,24 +547,43 @@ func ToEntry(n Node) (e *Entry) {
 			// We don't expect this to happen, so throw an error.
 			// BUG(borman): I think a deviate statement might trigger this.
 			e.addError(fmt.Errorf("%s: unexpected type in %s:%s", Source(n), n.Kind(), n.NName()))
+
+		// TODO(borman): unimplemented keywords
+		case "belongs-to",
+			"contact",
+			"default",
+			"deviation",
+			"extension",
+			"feature",
+			"identity",
+			"if-feature",
+			"mandatory",
+			"max-elements",
+			"min-elements",
+			"must",
+			"namespace",
+			"ordered-by",
+			"organization",
+			"presence",
+			"reference",
+			"revision",
+			"status",
+			"typedef",
+			"unique",
+			"when",
+			"yang-version":
+			continue
+
+		case "Ext", "Name", "Parent", "Statement":
+			// These are meta-keywords used internally
+			continue
+		default:
+			e.addError(fmt.Errorf("%s: unexpected statement: %s", Source(n), name))
+			continue
+
 		}
 		// We found at least one field.
 		found = true
-	}
-
-	// Now process the augments we found
-	// NOTE(borman): is it possible this will fail if the augment refers
-	// to some removed sibling that has not been processed?  Perhaps this
-	// should be done after the entire tree is built.  Is it correct to
-	// assume augment paths are data tree paths and not schema tree paths?
-	for _, a := range augments {
-		ae := a.Find(a.Name)
-		if ae == nil {
-			e.errorf("%s: augment %s not found", Source(a.Node), a.Name)
-			continue
-		}
-		// Augments do not have a prefix we merge in, just a node.
-		ae.merge(nil, a)
 	}
 	if !found {
 		return newError(n, "%T: cannot be converted to a *Entry", n)
@@ -521,18 +591,76 @@ func ToEntry(n Node) (e *Entry) {
 	return e
 }
 
+// Augment processes augments in e, return the number of augments processed
+// and the augments skipped.  If addErrors is true then missing augments will
+// generate errors.
+func (e *Entry) Augment(addErrors bool) (processed, skipped int) {
+	// Now process the augments we found
+	// NOTE(borman): is it possible this will fail if the augment refers
+	// to some removed sibling that has not been processed?  Perhaps this
+	// should be done after the entire tree is built.  Is it correct to
+	// assume augment paths are data tree paths and not schema tree paths?
+	// Augments can depend upon augments.  We need to figure out how to
+	// order the augments (or just keep trying until we can make no further
+	// progress)
+	var sa []*Entry
+	for _, a := range e.Augments {
+		ae := a.Find(a.Name)
+		if ae == nil {
+			if addErrors {
+				e.errorf("%s: augment %s not found", Source(a.Node), a.Name)
+			}
+			skipped++
+			sa = append(sa, a)
+			continue
+		}
+		// Augments do not have a prefix we merge in, just a node.
+		processed++
+		ae.merge(nil, a)
+	}
+	e.Augments = sa
+	return processed, skipped
+}
+
+// FixChoice inserts missing Case entries in a choice
+func (e *Entry) FixChoice() {
+	if e.Kind == ChoiceEntry && len(e.Errors) == 0 {
+		for k, ce := range e.Dir {
+			if ce.Kind != CaseEntry {
+				ne := &Entry{
+					Parent: e,
+					Node:   ce.Node,
+					Name:   ce.Name,
+					Kind:   CaseEntry,
+					Config: ce.Config,
+					Prefix: ce.Prefix,
+					Dir:    map[string]*Entry{ce.Name: ce},
+				}
+				ce.Parent = ne
+				e.Dir[k] = ne
+			}
+		}
+	}
+	for _, ce := range e.Dir {
+		ce.FixChoice()
+	}
+}
+
 // ReadOnly returns true if e is a read-only variable (config == false).
 // If Config is unset in e, then false is returned if e has no parent,
 // otherwise the value parent's ReadOnly is returned.
 func (e *Entry) ReadOnly() bool {
-	if e == nil {
+	switch {
+	case e == nil:
 		// We made it all the way to the root of the tree
 		return false
-	}
-	if e.Config == TSUnset {
+	case e.Kind == OutputEntry:
+		return true
+	case e.Config == TSUnset:
 		return e.Parent.ReadOnly()
+	default:
+		return !e.Config.Value()
 	}
-	return !e.Config.Value()
 }
 
 // Find finds the Entry named by name relative to e.
@@ -545,6 +673,18 @@ func (e *Entry) Find(name string) *Entry {
 		e = e.Parent
 	}
 	parts := strings.Split(name[1:], "/")
+
+	if prefix, _ := getPrefix(parts[0]); prefix != "" {
+		m, err := e.Modules().FindModuleByPrefix(prefix)
+		if err != nil {
+			e.addError(err)
+			return nil
+		}
+		if e.Node.(*Module) != m {
+			e = ToEntry(m)
+		}
+	}
+
 	for _, part := range parts {
 		_, part = getPrefix(part)
 		ne := e.Dir[part]

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -816,6 +816,7 @@ func (s sortedErrors) Less(i, j int) bool {
 
 // errorSort sorts the strings in the errors slice assuming each line starts
 // with file:line:col.  Line and column number are sorted numerically.
+// Duplicate errors are stripped.
 func errorSort(errors []error) []error {
 	switch len(errors) {
 	case 0:

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -274,8 +274,7 @@ func (e *Entry) GetErrors() []error {
 			seen[err] = true
 		}
 	})
-	errorSort(errs)
-	return errs
+	return errorSort(errs)
 }
 
 // asKind sets the kind of e to k and returns e.
@@ -817,16 +816,26 @@ func (s sortedErrors) Less(i, j int) bool {
 
 // errorSort sorts the strings in the errors slice assuming each line starts
 // with file:line:col.  Line and column number are sorted numerically.
-func errorSort(errors []error) {
-	if len(errors) < 2 {
-		return
+func errorSort(errors []error) []error {
+	switch len(errors) {
+	case 0:
+		return nil
+	case 1:
+		return errors
 	}
 	elist := make(sortedErrors, len(errors))
 	for x, err := range errors {
 		elist[x] = sError{err.Error(), err}
 	}
 	sort.Sort(elist)
-	for x, err := range elist {
-		errors[x] = err.err
-	}
+	errors = make([]error, len(errors))
+	i := 0
+        for _, err := range elist {
+                if i > 0 && reflect.DeepEqual(err.err, errors[i-1]) {
+                        continue
+                }
+                errors[i] = err.err
+                i++
+        }
+	return errors
 }

--- a/pkg/yang/file_test.go
+++ b/pkg/yang/file_test.go
@@ -95,7 +95,7 @@ func TestScanForPathsAndAddModules(t *testing.T) {
 	ms := NewModules()
 	for _, name := range modules {
 		if _, err := ms.GetModule(name); err != nil {
-			t.Error(err)
+			t.Errorf("getting %s: %v", name, err)
 		}
 	}
 

--- a/pkg/yang/find.go
+++ b/pkg/yang/find.go
@@ -18,6 +18,7 @@ package yang
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 )
@@ -52,7 +53,8 @@ func FindGrouping(n Node, name string) *Grouping {
 		// always a pointer to a structure,
 		e := reflect.ValueOf(n).Elem()
 		if !e.IsValid() {
-			fmt.Printf("%s: unknown grouping\n", name)
+			// TODO(borman): we shoud return an error somehow
+			fmt.Fprintf(os.Stderr, "%s: unknown grouping\n", name)
 			return nil
 		}
 		v := e.FieldByName("Grouping")

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -58,6 +58,16 @@ type Statement struct {
 	col  int // 1's based column number
 }
 
+// FakeStatment returns a statement filled in with keyword, file, line and col.
+func FakeStatement(keyword, file string, line, col int) *Statement {
+	return &Statement{
+		keyword: keyword,
+		file:    file,
+		line:    line,
+		col:     col,
+	}
+}
+
 // Make Statement statisfy Node
 
 func (s *Statement) NName() string         { return s.argument }

--- a/proto.go
+++ b/proto.go
@@ -1,0 +1,198 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/openconfig/goyang/pkg/indent"
+	"github.com/openconfig/goyang/pkg/yang"
+)
+
+func init() {
+	register(&formatter {
+		name: "proto",
+		f: doProto,
+		help: "display tree in a proto like format",
+	})
+}
+
+func doProto(w io.Writer, entries []*yang.Entry) {
+	for _, e := range entries {
+		for _, e := range flatten(e) {
+			FormatNode(w, e)
+		}
+	}
+}
+
+
+// kind2proto maps base yang types to protocol buffer types.
+// TODO(borman): do TODO types.
+var kind2proto = map[yang.TypeKind]string{
+	yang.Yint8:   "int32",  // int in range [-128, 127]
+	yang.Yint16:  "int32",  // int in range [-32768, 32767]
+	yang.Yint32:  "int32",  // int in range [-2147483648, 2147483647]
+	yang.Yint64:  "int64",  // int in range [-9223372036854775808, 9223372036854775807]
+	yang.Yuint8:  "uint32", // int in range [0, 255]
+	yang.Yuint16: "uint32", // int in range [0, 65535]
+	yang.Yuint32: "uint32", // int in range [0, 4294967295]
+	yang.Yuint64: "uint64", // int in range [0, 18446744073709551615]
+
+	yang.Ybinary:             "bytes",          // arbitrary data
+	yang.Ybits:               "TODO-bits",      // set of bits or flags
+	yang.Ybool:               "bool",           // true or false
+	yang.Ydecimal64:          "TODO-decimal64", // signed decimal number
+	yang.Yenum:               "TODO-enum",      // enumerated strings
+	yang.Yidentityref:        "string",         // reference to abstrace identity
+	yang.YinstanceIdentifier: "TODO-ii",        // reference of a data tree node
+	yang.Yleafref:            "string",         // reference to a leaf instance
+	yang.Ystring:             "string",         // human readable string
+	yang.Yunion:              "TODO-union",     // choice of types
+}
+
+func isStream(e *yang.Entry) bool {
+	for _, ext := range e.Exts {
+		if ext.Kind() == "grpc:stream" {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatNode writes e, formatted almost like a protobuf message, to w.
+func FormatNode(w io.Writer, e *yang.Entry) {
+	var names []string
+
+	for k, se := range e.Dir {
+		if se.RPC != nil {
+			names = append(names, k)
+		}
+	}
+	needEmpty := false
+	if len(names) > 0 {
+		sort.Strings(names)
+		fmt.Fprintf(w, "service %s {\n", fixName(e.Name))
+		for _, k := range names {
+			rpc := e.Dir[k].RPC
+			k = fixName(k)
+			iName := "Empty"
+			oName := "Empty"
+			if rpc.Input != nil {
+				iName = k + "Request"
+				rpc.Input.Name = iName
+				if isStream(rpc.Input) {
+					iName = "stream " + iName
+				}
+			}
+			if rpc.Output != nil {
+				oName = k + "Response"
+				rpc.Output.Name = oName
+				if isStream(rpc.Output) {
+					oName = "stream " + oName
+				}
+			}
+			needEmpty = needEmpty || rpc.Input == nil || rpc.Output == nil
+			fmt.Fprintf(w, "  rpc %s (%s) returns (%s);\n", k, iName, oName)
+		}
+		fmt.Fprintln(w, "}")
+		for _, k := range names {
+			rpc := e.Dir[k].RPC
+			if rpc.Input != nil {
+				FormatNode(w, rpc.Input)
+			}
+			if rpc.Output != nil {
+				FormatNode(w, rpc.Output)
+			}
+		}
+	}
+
+	if needEmpty {
+		fmt.Fprintln(w, "\nmessage Empty { }")
+	}
+
+	names = nil
+	for k, se := range e.Dir {
+		if se.RPC == nil {
+			names = append(names, k)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	if e.Description != "" {
+		fmt.Fprintln(indent.NewWriter(w, "// "), e.Description)
+	}
+	fmt.Fprintf(w, "message %s {\n", fixName(e.Name))
+
+	sort.Strings(names)
+	for x, k := range names {
+		se := e.Dir[k]
+		if se.Description != "" {
+			fmt.Fprintln(indent.NewWriter(w, "  // "), se.Description)
+		}
+		if se.ListAttr != nil {
+			fmt.Fprint(w, "  repeated ")
+		} else {
+			fmt.Fprint(w, "  optional ")
+		}
+		if len(se.Dir) == 0 && se.Type != nil {
+			// TODO(borman): this is probably an empty container.
+			kind := "UNKNOWN TYPE"
+			if se.Type != nil {
+				kind = kind2proto[se.Type.Kind]
+			}
+			fmt.Fprintf(w, "%s %s = %d; // %s\n", kind, fixName(k), x+1, yang.Source(se.Node))
+			continue
+		}
+		fmt.Fprintf(w, "%s %s = %d; // %s\n", fixName(se.Name), fixName(k), x+1, yang.Source(se.Node))
+	}
+	// { to match the brace below to keep brace matching working
+	fmt.Fprintln(w, "}")
+}
+
+// fixedNames maps a fixed name back to its origial name.
+var fixedNames = map[string]string{}
+
+func fixName(s string) string {
+	cc := yang.CamelCase(s)
+	if cc != s {
+		if o := fixedNames[cc]; o != "" && o != s {
+			fmt.Printf("Collision on %s and %s\n", o, s)
+		}
+		fixedNames[cc] = s
+	}
+	return cc
+}
+
+// flatten returns a slice of all directory entries in e and e's decendents.
+func flatten(e *yang.Entry) []*yang.Entry {
+	if e == nil || len(e.Dir) == 0 {
+		return nil
+	}
+	f := []*yang.Entry{e}
+	var names []string
+	for n := range e.Dir {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		f = append(f, flatten(e.Dir[n])...)
+	}
+	return f
+}

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,112 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/openconfig/goyang/pkg/indent"
+	"github.com/openconfig/goyang/pkg/yang"
+)
+
+func init() {
+        register(&formatter {
+                name: "tree",
+                f: doTree,
+                help: "display in a tree format",
+        })
+}
+
+func doTree(w io.Writer, entries []*yang.Entry) {
+        for _, e := range entries {
+		Write(w, e)
+        }
+}
+
+// Write writes e, formatted, and all of its children, to w.
+func Write(w io.Writer, e *yang.Entry) {
+	if e.Description != "" {
+		fmt.Fprintln(w)
+		fmt.Fprintln(indent.NewWriter(w, "// "), e.Description)
+	}
+	if len(e.Exts) > 0 {
+		fmt.Fprintf(w, "extensions: {\n")
+		for _, ext := range e.Exts {
+			if n := ext.NName(); n != "" {
+				fmt.Fprintf(w, "  %s %s;\n", ext.Kind(), n)
+			} else {
+				fmt.Fprintf(w, "  %s;\n", ext.Kind())
+			}
+		}
+		fmt.Fprintln(w, "}")
+	}
+	switch {
+	case e.RPC != nil:
+		fmt.Fprintf(w, "RPC: ")
+	case e.ReadOnly():
+		fmt.Fprintf(w, "RO: ")
+	default:
+		fmt.Fprintf(w, "rw: ")
+	}
+	if e.Type != nil {
+		fmt.Fprintf(w, "%s ", getTypeName(e))
+	}
+	name := e.Name
+	if e.Prefix != "" {
+		name = e.Prefix + ":" + name
+	}
+	switch {
+	case e.Dir == nil && e.ListAttr != nil:
+		fmt.Fprintf(w, "[]%s\n", name)
+		return
+	case e.Dir == nil:
+		fmt.Fprintf(w, "%s\n", name)
+		return
+	case e.ListAttr != nil:
+		fmt.Fprintf(w, "[%s]%s {\n", e.Key, name) //}
+	default:
+		fmt.Fprintf(w, "%s {\n", name) //}
+	}
+	if r := e.RPC; r != nil {
+		if r.Input != nil {
+			Write(indent.NewWriter(w, "  "), r.Input)
+		}
+		if r.Output != nil {
+			Write(indent.NewWriter(w, "  "), r.Output)
+		}
+	}
+	var names []string
+	for k := range e.Dir {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for _, k := range names {
+		Write(indent.NewWriter(w, "  "), e.Dir[k])
+	}
+	// { to match the brace below to keep brace matching working
+	fmt.Fprintln(w, "}")
+}
+
+func getTypeName(e *yang.Entry) string {
+	if e == nil || e.Type == nil {
+		return ""
+	}
+	// Return our root's type name.
+	// This is should be the builtin type-name
+	// for this entry.
+	return e.Type.Root.Name
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,99 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/openconfig/goyang/pkg/yang"
+)
+
+func init() {
+	register(&formatter{
+		name: "types",
+		f:    doTypes,
+		help: "display found types",
+	})
+}
+
+func doTypes(w io.Writer, entries []*yang.Entry) {
+	types := Types{}
+	for _, e := range entries {
+		types.AddEntry(e)
+	}
+
+	for t := range types {
+		YTPrint(w, t)
+	}
+}
+
+// Types keeps track of all the YangTypes defined.
+type Types map[*yang.YangType]struct{}
+
+// AddEntry adds all types defined in e and its decendents to t.
+func (t Types) AddEntry(e *yang.Entry) {
+	if e == nil {
+		return
+	}
+	if e.Type != nil {
+		t[e.Type.Root] = struct{}{}
+	}
+	for _, d := range e.Dir {
+		t.AddEntry(d)
+	}
+}
+
+// YTPrint prints type t in a moderately human readable format to w.
+func YTPrint(w io.Writer, t *yang.YangType) {
+	if t.Base != nil {
+		fmt.Fprintf(w, "%s: ", yang.Source(t.Base))
+	}
+	fmt.Fprintf(w, "%s", t.Root.Name)
+	if t.Kind.String() != t.Root.Name {
+		fmt.Fprintf(w, "(%s)", t.Kind)
+	}
+	if t.Units != "" {
+		fmt.Fprintf(w, " units=%s", t.Units)
+	}
+	if t.Default != "" {
+		fmt.Fprintf(w, " default=%q", t.Default)
+	}
+	if t.FractionDigits != 0 {
+		fmt.Fprintf(w, " fraction-digits=%d", t.FractionDigits)
+	}
+	if len(t.Length) > 0 {
+		fmt.Fprintf(w, " length=%s", t.Length)
+	}
+	if t.Kind == yang.YinstanceIdentifier && !t.OptionalInstance {
+		fmt.Fprintf(w, " required")
+	}
+	if t.Kind == yang.Yleafref && t.Path != "" {
+		fmt.Fprintf(w, " path=%q", t.Path)
+	}
+	if len(t.Pattern) > 0 {
+		fmt.Fprintf(w, " pattern=%s", strings.Join(t.Pattern, "|"))
+	}
+	if len(t.Type) > 0 {
+		fmt.Fprintf(w, " union...")
+	}
+
+	b := yang.BaseTypedefs[t.Kind.String()].YangType
+	if len(t.Range) > 0 && !t.Range.Equal(b.Range) {
+		fmt.Fprintf(w, " range=%s", t.Range)
+	}
+	fmt.Fprintf(w, ";\n")
+}

--- a/yang.go
+++ b/yang.go
@@ -29,11 +29,8 @@
 // If PATH is specified, it is considered a comma separated list of paths
 // to append to the search directory.
 //
-// FORMAT, which defaults to "tree", specifes the format of output to produce:
-//
-//   tree   All modules in tree form
-//   proto  All directory nodes as proto structures
-//   types  All type definitions
+// FORMAT, which defaults to "tree", specifes the format of output to produce.
+// Use "goyang --help" for a list of available formats.
 //
 // THIS PROGRAM IS STILL JUST A DEVELOPMENT TOOL.
 package main
@@ -43,30 +40,24 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"runtime/trace"
 	"sort"
 	"strings"
 
-	"github.com/openconfig/goyang/pkg/indent"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/pborman/getopt"
 )
 
-// Types keeps track of all the YangTypes defined.
-type Types map[*yang.YangType]struct{}
+type formatter struct {
+	name string
+	f    func(io.Writer, []*yang.Entry)
+	help string
+}
 
-// AddEntry adds all types defined in e and its decendents to t.
-func (t Types) AddEntry(e *yang.Entry) {
-	if e == nil {
-		return
-	}
-	if e.Type != nil {
-		t[e.Type.Root] = struct{}{}
-	}
-	for _, d := range e.Dir {
-		t.AddEntry(d)
-	}
-	t.AddEntry(e.Choice)
-	t.AddEntry(e.Case)
+var formatters = map[string]*formatter{}
+
+func register(f *formatter) {
+	formatters[f.name] = f
 }
 
 // exitIfError writes errs to standard error and exits with an exit status of 1.
@@ -76,16 +67,56 @@ func exitIfError(errs []error) {
 		for _, err := range errs {
 			fmt.Fprintln(os.Stderr, err)
 		}
-		os.Exit(1)
+		stop(1)
 	}
 }
 
+var stop = os.Exit
+
 func main() {
 	format := "tree"
+	formats := make([]string, 0, len(formatters))
+	for k := range formatters {
+		formats = append(formats, k)
+	}
+	sort.Strings(formats)
+
+	var traceP string
+	var help bool
 	getopt.CommandLine.ListVarLong(&yang.Path, "path", 0, "comma separated list of directories to add to PATH")
-	getopt.CommandLine.StringVarLong(&format, "format", 0, "format to display: tree, proto, types")
+	getopt.CommandLine.StringVarLong(&format, "format", 0, "format to display: "+strings.Join(formats, ", "))
+	getopt.CommandLine.StringVarLong(&traceP, "trace", 0, "file to write trace into")
+	getopt.CommandLine.BoolVarLong(&help, "help", '?', "display help")
 
 	getopt.Parse()
+
+	if traceP != "" {
+		fp, err := os.Create(traceP)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		trace.Start(fp)
+		stop = func(c int) { trace.Stop(); os.Exit(c) }
+		defer func() { trace.Stop() }()
+	}
+
+	if help {
+		getopt.CommandLine.PrintUsage(os.Stderr)
+		fmt.Fprintf(os.Stderr, "\nFormats:\n")
+		for _, fn := range formats {
+			f := formatters[fn]
+			fmt.Fprintf(os.Stderr, "    %s - %s\n", f.name, f.help)
+		}
+		stop(0)
+	}
+
+	if _, ok := formatters[format]; !ok {
+		fmt.Fprintf(os.Stderr, "%s: invalid format.  Choices are %s\n", format, strings.Join(formats, ", "))
+		stop(1)
+
+	}
+
 	files := getopt.Args()
 
 	if len(files) > 0 && !strings.HasSuffix(files[0], ".yang") {
@@ -107,7 +138,7 @@ func main() {
 		}
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			stop(1)
 		}
 	}
 
@@ -117,6 +148,9 @@ func main() {
 			continue
 		}
 	}
+
+	// Process the read files, exiting if any errors were found.
+	exitIfError(ms.Process())
 
 	// Keep track of the top level modules we read in.
 	// Those are the only modules we want to print below.
@@ -130,217 +164,10 @@ func main() {
 		}
 	}
 	sort.Strings(names)
-
-	// Print any errors found in the tree.  This will return false if
-	// there were no errors.
-	exitIfError(ms.Process())
-
-	switch format {
-	case "tree":
-		for _, n := range names {
-			Write(os.Stdout, yang.ToEntry(mods[n]))
-		}
-	case "proto":
-		for _, n := range names {
-			for _, e := range flatten(yang.ToEntry(mods[n])) {
-				FormatNode(os.Stdout, e)
-			}
-		}
-	case "types":
-		types := Types{}
-		for _, n := range names {
-			types.AddEntry(yang.ToEntry(mods[n]))
-		}
-
-		for t := range types {
-			YTPrint(os.Stdout, t)
-		}
-	default:
-		fmt.Fprintf(os.Stderr, "unknown format: %s\n", format)
-		os.Exit(1)
-	}
-}
-
-// fixedNames maps a fixed name back to its origial name.
-var fixedNames = map[string]string{}
-
-func fixName(s string) string {
-	cc := yang.CamelCase(s)
-	if cc != s {
-		if o := fixedNames[cc]; o != "" && o != s {
-			fmt.Printf("Collision on %s and %s\n", o, s)
-		}
-		fixedNames[cc] = s
-	}
-	return cc
-}
-
-func getTypeName(e *yang.Entry) string {
-	if e == nil || e.Type == nil {
-		return ""
-	}
-	// Return our root's type name.
-	// This is should be the builtin type-name
-	// for this entry.
-	return e.Type.Root.Name
-}
-
-// Write writes e, formatted, and all of its children, to w.
-func Write(w io.Writer, e *yang.Entry) {
-	if e.Description != "" {
-		fmt.Fprintln(w)
-		fmt.Fprintln(indent.NewWriter(w, "// "), e.Description)
-	}
-	if e.ReadOnly() {
-		fmt.Fprintf(w, "RO: ")
-	} else {
-		fmt.Fprintf(w, "rw: ")
-	}
-	if e.Type != nil {
-		fmt.Fprintf(w, "%s ", getTypeName(e))
-	}
-	switch {
-	case e.Dir == nil && e.ListAttr != nil:
-		fmt.Fprintf(w, "[]%s\n", e.Name)
-		return
-	case e.Dir == nil:
-		fmt.Fprintf(w, "%s\n", e.Name)
-		return
-	case e.ListAttr != nil:
-		fmt.Fprintf(w, "[%s]%s {\n", e.Key, e.Name) //}
-	default:
-		fmt.Fprintf(w, "%s {\n", e.Name) //}
-	}
-	var names []string
-	for k := range e.Dir {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-	for _, k := range names {
-		Write(indent.NewWriter(w, "  "), e.Dir[k])
-	}
-	// { to match the brace below to keep brace matching working
-	fmt.Fprintln(w, "}")
-}
-
-// kind2proto maps base yang types to protocol buffer types.
-// TODO(borman): do TODO types.
-var kind2proto = map[yang.TypeKind]string{
-	yang.Yint8:   "int32",  // int in range [-128, 127]
-	yang.Yint16:  "int32",  // int in range [-32768, 32767]
-	yang.Yint32:  "int32",  // int in range [-2147483648, 2147483647]
-	yang.Yint64:  "int64",  // int in range [-9223372036854775808, 9223372036854775807]
-	yang.Yuint8:  "uint32", // int in range [0, 255]
-	yang.Yuint16: "uint32", // int in range [0, 65535]
-	yang.Yuint32: "uint32", // int in range [0, 4294967295]
-	yang.Yuint64: "uint64", // int in range [0, 18446744073709551615]
-
-	yang.Ybinary:             "bytes",          // arbitrary data
-	yang.Ybits:               "TODO-bits",      // set of bits or flags
-	yang.Ybool:               "bool",           // true or false
-	yang.Ydecimal64:          "TODO-decimal64", // signed decimal number
-	yang.Yenum:               "TODO-enum",      // enumerated strings
-	yang.Yidentityref:        "string",         // reference to abstrace identity
-	yang.YinstanceIdentifier: "TODO-ii",        // reference of a data tree node
-	yang.Yleafref:            "string",         // reference to a leaf instance
-	yang.Ystring:             "string",         // human readable string
-	yang.Yunion:              "TODO-union",     // choice of types
-}
-
-// FormatNode writes e, formatted almost like a protobuf message, to w.
-func FormatNode(w io.Writer, e *yang.Entry) {
-	fmt.Fprintln(w)
-	if e.Description != "" {
-		fmt.Fprintln(indent.NewWriter(w, "// "), e.Description)
-	}
-	fmt.Fprintf(w, "message %s {\n", fixName(e.Name))
-
-	var names []string
-	for k := range e.Dir {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-	for x, k := range names {
-		se := e.Dir[k]
-		if se.Description != "" {
-			fmt.Fprintln(indent.NewWriter(w, "  // "), se.Description)
-		}
-		if se.ListAttr != nil {
-			fmt.Fprint(w, "  repeated ")
-		} else {
-			fmt.Fprint(w, "  optional ")
-		}
-		if len(se.Dir) == 0 && se.Type != nil {
-			// TODO(borman): this is probably an empty container.
-			kind := "UNKNOWN TYPE"
-			if se.Type != nil {
-				kind = kind2proto[se.Type.Kind]
-			}
-			fmt.Fprintf(w, "%s %s = %d; // %s\n", kind, fixName(k), x+1, yang.Source(se.Node))
-			continue
-		}
-		fmt.Fprintf(w, "%s %s = %d; // %s\n", fixName(se.Name), fixName(k), x+1, yang.Source(se.Node))
-	}
-	// { to match the brace below to keep brace matching working
-	fmt.Fprintln(w, "}")
-}
-
-// flatten returns a slice of all directory entries in e and e's decendents.
-func flatten(e *yang.Entry) []*yang.Entry {
-	if e == nil || len(e.Dir) == 0 {
-		return nil
-	}
-	f := []*yang.Entry{e}
-	var names []string
-	for n := range e.Dir {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	for _, n := range names {
-		f = append(f, flatten(e.Dir[n])...)
-	}
-	f = append(f, flatten(e.Choice)...)
-	f = append(f, flatten(e.Case)...)
-	return f
-}
-
-// YTPrint prints type t in a moderately human readable format to w.
-func YTPrint(w io.Writer, t *yang.YangType) {
-	if t.Base != nil {
-		fmt.Fprintf(w, "%s: ", yang.Source(t.Base))
-	}
-	fmt.Fprintf(w, "%s", t.Root.Name)
-	if t.Kind.String() != t.Root.Name {
-		fmt.Fprintf(w, "(%s)", t.Kind)
-	}
-	if t.Units != "" {
-		fmt.Fprintf(w, " units=%s", t.Units)
-	}
-	if t.Default != "" {
-		fmt.Fprintf(w, " default=%q", t.Default)
-	}
-	if t.FractionDigits != 0 {
-		fmt.Fprintf(w, " fraction-digits=%d", t.FractionDigits)
-	}
-	if len(t.Length) > 0 {
-		fmt.Fprintf(w, " length=%s", t.Length)
-	}
-	if t.Kind == yang.YinstanceIdentifier && !t.OptionalInstance {
-		fmt.Fprintf(w, " required")
-	}
-	if t.Kind == yang.Yleafref && t.Path != "" {
-		fmt.Fprintf(w, " path=%q", t.Path)
-	}
-	if len(t.Pattern) > 0 {
-		fmt.Fprintf(w, " pattern=%s", strings.Join(t.Pattern, "|"))
-	}
-	if len(t.Type) > 0 {
-		fmt.Fprintf(w, " union...")
+	entries := make([]*yang.Entry, len(names))
+	for x, n := range names {
+		entries[x] = yang.ToEntry(mods[n])
 	}
 
-	b := yang.BaseTypedefs[t.Kind.String()].YangType
-	if len(t.Range) > 0 && !t.Range.Equal(b.Range) {
-		fmt.Fprintf(w, " range=%s", t.Range)
-	}
-	fmt.Fprintf(w, ";\n")
+	formatters[format].f(os.Stdout, entries)
 }

--- a/yang.go
+++ b/yang.go
@@ -48,6 +48,8 @@ import (
 	"github.com/pborman/getopt"
 )
 
+// Each format must register a formatter with register.  The function f will
+// be called once with the set of yang Entry trees generated.
 type formatter struct {
 	name string
 	f    func(io.Writer, []*yang.Entry)


### PR DESCRIPTION
Add RPC handling and improve the handling of Augmentation.

The RPC handling was relatively small, but also required better handling of extensions (to indicate streaming RPCs).

The augmentation changes were more pervasive as tests showed several deficiencies.  Augmentation now handles augments of augments as well as augmenting modules you are not part of.

If the YANG source uses the shortcut for leaf cases, goyang automatically inserts the missing case statements.

The classification for an Entry structure was also improved making it easier for formatters.