### PR TITLE
entry: Fix parents when merging a usage

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -756,6 +756,7 @@ func (e *Entry) merge(prefix *Value, oe *Entry) {
    %s: %s`, k, e.Name, Source(v.Node), v.Name, Source(se.Node), se.Name)
 			e.addError(er.Errors[0])
 		} else {
+			v.Parent = e
 			e.Dir[k] = v
 		}
 	}


### PR DESCRIPTION
By setting the parent on the entries as they merge, the correct paths
are shown. Previously, the name of the grouping was also seen, whereas
this is not part of the path as described by XPath or the JSONPath specs.

Add a regression test to confirm we see the correct path with this
change to entry.go, without the name of the grouping.

Addresses one major cause of #9.