### PR TITLE
Set every Entry's Prefix 

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -73,7 +73,7 @@ type Entry struct {
 	Errors      []error   // list of errors encounterd on this node
 	Kind        EntryKind // kind of Entry
 	Config      TriState  // config state of this entry, if known
-	Prefix      string    // prefix to use from this point down
+	Prefix      *Value    // prefix to use from this point down
 
 	// Fields associated with directory nodes
 	Dir map[string]*Entry
@@ -168,6 +168,7 @@ const (
 	OutputEntry
 )
 
+// EntryKindToName maps EntryKind to their names
 var EntryKindToName = map[EntryKind]string{
 	LeafEntry:         "Leaf",
 	DirectoryEntry:    "Directory",
@@ -455,7 +456,7 @@ func ToEntry(n Node) (e *Entry) {
 			}
 		case "prefix":
 			if v := fv.Interface().(*Value); v != nil {
-				e.Prefix = v.Name
+				e.Prefix = v
 			}
 		case "augment":
 			for _, a := range fv.Interface().([]*Augment) {
@@ -748,7 +749,7 @@ func (e *Entry) merge(prefix *Value, oe *Entry) {
 	for k, v := range oe.Dir {
 		v := v.dup()
 		if prefix != nil {
-			v.Prefix = prefix.Name
+			v.Prefix = prefix
 		}
 		if se := e.Dir[k]; se != nil {
 			er := newError(oe.Node, `Duplicate node %q in %q from:

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -588,6 +588,13 @@ func ToEntry(n Node) (e *Entry) {
 	if !found {
 		return newError(n, "%T: cannot be converted to a *Entry", n)
 	}
+	// If prefix isn't set, provide it based on our root node (module)
+	if e.Prefix == nil {
+		if m := RootNode(e.Node); m != nil {
+			e.Prefix = m.getPrefix()
+		}
+	}
+
 	return e
 }
 

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -202,3 +202,19 @@ func TestUsesParent(t *testing.T) {
 		t.Errorf("want %s, got %s", expected, used.Path())
 	}
 }
+
+func TestPrefixes(t *testing.T) {
+	ms := NewModules()
+	for _, tt := range parentTestModules {
+		_ = ms.Parse(tt.in, tt.name)
+	}
+
+	efoo, _ := ms.GetModule("foo")
+	if efoo.Prefix.Name != "foo" {
+		t.Errorf(`want prefix "foo", got %q`, efoo.Prefix.Name)
+	}
+	used := efoo.Dir["foo-c"].Dir["test1"]
+	if used.Prefix.Name != "bar" {
+		t.Errorf(`want prefix "bar", got %q`, used.Prefix.Name)
+	}
+}

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -179,14 +179,23 @@ func (s *Module) FullName() string {
 // GetPrefix returns the proper prefix of m.  Useful when looking up types
 // in modules found by FindModuleByPrefix.
 func (m *Module) GetPrefix() string {
-	if m == nil {
+	pfx := m.getPrefix()
+	if pfx == nil {
 		// This case can be true during testing.
 		return ""
 	}
-	if m.Prefix != nil {
-		return m.Prefix.Name
+	return pfx.Name
+}
+
+func (m *Module) getPrefix() *Value {
+	if m == nil {
+		return nil
+	} else if m.Prefix != nil {
+		return m.Prefix
+	} else if m.BelongsTo != nil {
+		return m.BelongsTo.Prefix
 	}
-	return m.BelongsTo.Prefix.Name
+	return nil
 }
 
 // An Import is defined in: http://tools.ietf.org/html/rfc6020#section-7.1.5

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -189,7 +189,7 @@ func (m *Module) GetPrefix() string {
 	return m.BelongsTo.Prefix.Name
 }
 
-// An Inport is defined in: http://tools.ietf.org/html/rfc6020#section-7.1.5
+// An Import is defined in: http://tools.ietf.org/html/rfc6020#section-7.1.5
 type Import struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`

--- a/tree.go
+++ b/tree.go
@@ -24,17 +24,17 @@ import (
 )
 
 func init() {
-        register(&formatter {
-                name: "tree",
-                f: doTree,
-                help: "display in a tree format",
-        })
+	register(&formatter{
+		name: "tree",
+		f:    doTree,
+		help: "display in a tree format",
+	})
 }
 
 func doTree(w io.Writer, entries []*yang.Entry) {
-        for _, e := range entries {
+	for _, e := range entries {
 		Write(w, e)
-        }
+	}
 }
 
 // Write writes e, formatted, and all of its children, to w.
@@ -66,8 +66,8 @@ func Write(w io.Writer, e *yang.Entry) {
 		fmt.Fprintf(w, "%s ", getTypeName(e))
 	}
 	name := e.Name
-	if e.Prefix != "" {
-		name = e.Prefix + ":" + name
+	if e.Prefix != nil {
+		name = e.Prefix.Name + ":" + name
 	}
 	switch {
 	case e.Dir == nil && e.ListAttr != nil:


### PR DESCRIPTION
Change `Entry.Prefix` from a string to a `*Value`, set it based on the current `Module`s `Prefix` if it is not explicitly set.

Add a test to confirm we get the correct prefix for a `uses` case across YANG modules.

This is designed to address issue #7, the first issue related to a parent issue (#5)