### PR TITLE
Do not return nil modules from FindModuleByPrefix without setting error.

### DIFF
--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -196,6 +196,9 @@ func (ms *Modules) FindModule(n Node) *Module {
 // an error.
 func (ms *Modules) FindModuleByPrefix(prefix string) (*Module, error) {
 	if m, ok := ms.byPrefix[prefix]; ok {
+		if m == nil {
+			return nil, fmt.Errorf("%s: no such prefix", prefix)
+		}
 		return m, nil
 	}
 	var found *Module


### PR DESCRIPTION
FindModuleByPrefix was returning nil,nil the second time it looked
for a missing prefix.  It now always returns an error if the module is
not found.