### PR TITLE
Add support for the Identity statement

### DIFF
--- a/pkg/yang/doc.go
+++ b/pkg/yang/doc.go
@@ -29,7 +29,7 @@
 // module:
 //
 //	// Get the tree for the module module-name by looking for the source
-//	// file namaed module-name.yang.
+//	// file named module-name.yang.
 //	e, errs := yang.GetModule("module-name" [, optional sources...])
 //	if len(errs) > 0 {
 //		for _, err := range errs {

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -88,6 +88,10 @@ type Entry struct {
 
 	RPC *RPCEntry // set if we are an RPC
 
+	// Identities that are defined in this context, this is set if the Entry
+	// is a module only.
+	Identities []*Identity
+
 	Augments []*Entry // Augments associated with this entry
 
 	// Extra maps all the unsupported fields to their values
@@ -544,6 +548,10 @@ func ToEntry(n Node) (e *Entry) {
 				e.RPC.Output.Name = "output"
 				e.RPC.Output.Kind = OutputEntry
 			}
+		case "identity":
+			if i := fv.Interface().([]*Identity); i != nil {
+				e.Identities = i
+			}
 		case "uses":
 			for _, a := range fv.Interface().([]*Uses) {
 				e.merge(nil, ToEntry(a))
@@ -553,6 +561,10 @@ func ToEntry(n Node) (e *Entry) {
 			// BUG(borman): I think a deviate statement might trigger this.
 			e.addError(fmt.Errorf("%s: unexpected type in %s:%s", Source(n), n.Kind(), n.NName()))
 
+		// Keywords that do not need to be handled as an Entry as they are added
+		// to other dictionaries.
+		case "typedef":
+			continue
 		// TODO(borman): unimplemented keywords
 		case "belongs-to",
 			"contact",
@@ -560,7 +572,6 @@ func ToEntry(n Node) (e *Entry) {
 			"deviation",
 			"extension",
 			"feature",
-			"identity",
 			"if-feature",
 			"mandatory",
 			"max-elements",
@@ -573,7 +584,6 @@ func ToEntry(n Node) (e *Entry) {
 			"reference",
 			"revision",
 			"status",
-			"typedef",
 			"unique",
 			"when",
 			"yang-version":

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yang
+
+import "testing"
+
+type modIn struct {
+	name    string
+	content string
+}
+
+type modOut struct {
+	name       string
+	identities []*idOut
+}
+
+type idOut struct {
+	idName   string
+	baseName string
+}
+
+type testCase struct {
+	name string
+	in   []*modIn
+	out  *modOut
+	err  string
+}
+
+// A set of test modules to parse as part of the test case.
+var testCases = []*testCase{
+	&testCase{
+		in: []*modIn{
+			&modIn{
+				name: "idtest-one",
+				content: `
+module idtest-one {
+  namespace "urn:idone";
+  prefix "idone";
+
+  identity TEST_ID;
+}
+    `},
+		},
+		out: &modOut{
+			name: "idtest-one",
+			identities: []*idOut{
+				&idOut{
+					idName: "TEST_ID",
+				},
+			},
+		},
+		err: "tc1: could not resolve identities",
+	},
+	&testCase{
+		in: []*modIn{
+			&modIn{
+				name: "idtest-two",
+				content: `
+module idtest-two {
+  namespace "urn:idtwo";
+  prefix "idone";
+
+  identity TEST_ID;
+  identity TEST_ID_TWO;
+  identity TEST_CHILD {
+    base TEST_ID;
+  }
+}
+    `},
+		},
+		out: &modOut{
+			name: "idtest-two",
+			identities: []*idOut{
+				&idOut{
+					idName: "TEST_ID",
+				},
+				&idOut{
+					idName: "TEST_ID_TWO",
+				},
+				&idOut{
+					idName:   "TEST_CHILD",
+					baseName: "TEST_ID",
+				},
+			},
+		},
+		err: "could not resolve identities",
+	},
+}
+
+func TestIdentityExtract(t *testing.T) {
+	for _, testCase := range testCases {
+		ms := NewModules()
+		for _, mod := range testCase.in {
+			_ = ms.Parse(mod.content, mod.name)
+		}
+		parsedMod, err := ms.GetModule(testCase.out.name)
+
+		if err != nil {
+			t.Errorf("could not parse module: %s", testCase.out.name)
+			continue
+		}
+
+		identityNames := make(map[string]*Identity)
+		for _, id := range parsedMod.Identities {
+			identityNames[id.Name] = id
+		}
+
+		for _, expID := range testCase.out.identities {
+			identity, ok := identityNames[expID.idName]
+
+			if !ok {
+				t.Errorf("%s: couldn't find %s", testCase.err, expID.idName)
+				continue
+			}
+
+			if expID.baseName != "" {
+				if expID.baseName != identity.Base.Name {
+					t.Errorf("%s: couldn't resolve expected base %s", testCase.err,
+						expID.baseName)
+				}
+			} else {
+				if identity.Base != nil {
+					t.Errorf("%s: identity had an unexpected base %s: %v", testCase.err,
+						identity.Name, identity.Base)
+				}
+			}
+		}
+	}
+}

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -40,7 +40,7 @@ type typeDictionary struct {
 // process them completely independently of eachother.
 var typeDict = typeDictionary{dict: map[Node]map[string]*Typedef{}}
 
-// add adds an entry to the typeDictorary d.
+// add adds an entry to the typeDictionary d.
 func (d *typeDictionary) add(n Node, name string, td *Typedef) {
 	defer d.mu.Unlock()
 	d.mu.Lock()
@@ -214,6 +214,7 @@ check:
 		return []error{fmt.Errorf("%s: no YangType defined for %s %s", Source(td), source, td.Name)}
 	}
 	y := *td.YangType
+
 	y.Base = td.Type
 	t.YangType = &y
 
@@ -238,6 +239,11 @@ check:
 		y.FractionDigits = int(i)
 	case t.FractionDigits != nil:
 		errs = append(errs, fmt.Errorf("%s: fraction-digits only allowed for decimal64 values", Source(t)))
+	case y.Kind == Yidentityref:
+		if t.IdentityBase == nil {
+			errs = append(errs, fmt.Errorf("%s: an identityref must specify a base", Source(t)))
+		}
+		y.IdentityBase = t.IdentityBase
 	}
 
 	if t.Range != nil {

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -246,9 +246,13 @@ func (e *EnumType) ValueMap() map[int64]string {
 // refer to either a builtin type or type specified with typedef.  Not
 // all fields in YangType are used for all types.
 type YangType struct {
-	Name             string
-	Kind             TypeKind    // Ynone if not a base type
-	Base             *Type       `json:"-"` // dervied from
+	Name string
+	Kind TypeKind // Ynone if not a base type
+	// Base represents the base Type if this is a derived type
+	Base *Type `json:"-"` // dervied from
+	// IdentityBase represents the "base" statement of an Identityref type.
+	// It is distinct from the Base specified above.
+	IdentityBase     *Value
 	Root             *YangType   `json:"-"` // root of this type that is the same
 	Bit              *EnumType   // bit position, "status" is lost
 	Enum             *EnumType   // enum name to value, "status" is lost

--- a/pkg/yang/types_test.go
+++ b/pkg/yang/types_test.go
@@ -50,6 +50,12 @@ func TestTypeResolve(t *testing.T) {
 		},
 		{
 			in: &Type{
+				Name: "identityref",
+			},
+			err: "unknown: an identityref must specify a base",
+		},
+		{
+			in: &Type{
 				Name:           "decimal64",
 				FractionDigits: &Value{Name: "42"},
 			},

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -148,12 +148,13 @@ func (s *Module) Kind() string {
 	}
 	return "module"
 }
-func (s *Module) ParentNode() Node       { return s.Parent }
-func (s *Module) NName() string          { return s.Name }
-func (s *Module) Statement() *Statement  { return s.Source }
-func (s *Module) Exts() []*Statement     { return s.Extensions }
-func (s *Module) Groupings() []*Grouping { return s.Grouping }
-func (s *Module) Typedefs() []*Typedef   { return s.Typedef }
+func (s *Module) ParentNode() Node        { return s.Parent }
+func (s *Module) NName() string           { return s.Name }
+func (s *Module) Statement() *Statement   { return s.Source }
+func (s *Module) Exts() []*Statement      { return s.Extensions }
+func (s *Module) Groupings() []*Grouping  { return s.Grouping }
+func (s *Module) Typedefs() []*Typedef    { return s.Typedef }
+func (s *Module) Identities() []*Identity { return s.Identity }
 
 // Current returns the most recent revision of this module, or "" if the module
 // has no revisions.
@@ -306,7 +307,7 @@ type Type struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
-	Base            *Value     `yang:"base"` // Name == identityref
+	IdentityBase    *Value     `yang:"base"` // Name == identityref
 	Bit             []*Bit     `yang:"bit"`
 	Enum            []*Enum    `yang:"enum"`
 	FractionDigits  *Value     `yang:"fraction-digits"` // Name == decimal64


### PR DESCRIPTION
Hi @pborman,

As discussed, this adds support for the `identity` statement to goyang. There are a couple of things that I'd appreciate your thoughts on:

* There seemed to be a conflict with `Base` in the `Type` struct, so I created separate bases for types (which the original code seemed to use) and `IdentityBase` specifically for the base statement of a YANG `identityref`.
* I added some basic test cases, I'll expand on these as I add some more functionality (building a resolved tree of identities). However, I split the commit up so that the PR wasn't too large.

PTAL :-) Comments on things that don't look good Go best practice are much appreciated!

r.

```
  * (M) doc.go:
    - fix minor typo.
  * (M) entry.go:
    - add support for an Entry to have a defined Identities
      struct member which stores the identities defined within
      that context.
    - add a new entry within the map of statements to indicate
      where a statement is supported, but doesn't require specific
      handling.
  * (M) types.go:
    - fix minor typo.
    - add support for the identityref's base statement and copy
      the value to the IdentityBase member of the entry struct.
    - ensure that an identityref without a base is considered
      erroneous.
  * (M) types_test.go:
    - add test for identityref without a base statement.
  * (M) yang.go:
    - add entries to the YANG structures storing the base of
      an identity, and an getter function for the identities of a
      module.
  * (A) identity_test.go
    - add tests for identities - created separate file based on
      need for resolution code.
```