### PR TITLE
Add support for resolving the values of an Identity

### DIFF
--- a/pkg/yang/doc.go
+++ b/pkg/yang/doc.go
@@ -29,7 +29,7 @@
 // module:
 //
 //	// Get the tree for the module module-name by looking for the source
-//	// file namaed module-name.yang.
+//	// file named module-name.yang.
 //	e, errs := yang.GetModule("module-name" [, optional sources...])
 //	if len(errs) > 0 {
 //		for _, err := range errs {

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -88,6 +88,10 @@ type Entry struct {
 
 	RPC *RPCEntry // set if we are an RPC
 
+	// Identities that are defined in this context, this is set if the Entry
+	// is a module only.
+	Identities []*Identity
+
 	Augments []*Entry // Augments associated with this entry
 
 	// Extra maps all the unsupported fields to their values
@@ -544,6 +548,10 @@ func ToEntry(n Node) (e *Entry) {
 				e.RPC.Output.Name = "output"
 				e.RPC.Output.Kind = OutputEntry
 			}
+		case "identity":
+			if i := fv.Interface().([]*Identity); i != nil {
+				e.Identities = i
+			}
 		case "uses":
 			for _, a := range fv.Interface().([]*Uses) {
 				e.merge(nil, ToEntry(a))
@@ -553,6 +561,10 @@ func ToEntry(n Node) (e *Entry) {
 			// BUG(borman): I think a deviate statement might trigger this.
 			e.addError(fmt.Errorf("%s: unexpected type in %s:%s", Source(n), n.Kind(), n.NName()))
 
+		// Keywords that do not need to be handled as an Entry as they are added
+		// to other dictionaries.
+		case "typedef":
+			continue
 		// TODO(borman): unimplemented keywords
 		case "belongs-to",
 			"contact",
@@ -560,7 +572,6 @@ func ToEntry(n Node) (e *Entry) {
 			"deviation",
 			"extension",
 			"feature",
-			"identity",
 			"if-feature",
 			"mandatory",
 			"max-elements",
@@ -573,7 +584,6 @@ func ToEntry(n Node) (e *Entry) {
 			"reference",
 			"revision",
 			"status",
-			"typedef",
 			"unique",
 			"when",
 			"yang-version":

--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -40,14 +40,12 @@ type resolvedIdentity struct {
 
 // isEmpty determines whether the resolvedIdentity struct value was defined.
 func (r resolvedIdentity) isEmpty() bool {
-	if r.Module == nil && r.Identity == nil {
-		return true
-	}
-	return false
+	return r.Module == nil && r.Identity == nil
 }
 
 // newResolvedIdentity creates a resolved identity from an identity and its
-// associated value.
+// associated value, and returns the prefixed name (Prefix:IdentityName)
+// along with the resolved identity.
 func newResolvedIdentity(m *Module, i *Identity) (string, *resolvedIdentity) {
 	r := &resolvedIdentity{
 		Module:   m,
@@ -103,6 +101,7 @@ func (mod *Module) findIdentityBase(baseStr string) (*resolvedIdentity, []error)
 		if extmod == nil {
 			errs = append(errs,
 				fmt.Errorf("can't find external module with prefix %s", basePrefix))
+			break
 		}
 
 		// Run through the identities within the remote module and find the

--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -83,10 +83,9 @@ func findIdentityBase(baseStr string, mod *Module) (*resolvedIdentity, []error) 
 		// This is a local identity which is defined within the current
 		// module
 		keyName := fmt.Sprintf("%s:%s", rootPrefix, baseName)
-
 		base, ok = identityDict.dict[keyName]
 		if !ok {
-			errs = append(errs, fmt.Errorf("can't resolve the local base %s", baseStr))
+			errs = append(errs, fmt.Errorf("can't resolve the local base %s as %s", baseStr, keyName))
 		}
 	default:
 		// This is an identity which is defined within another module

--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -1,0 +1,170 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yang
+
+import (
+	"fmt"
+	"sync"
+)
+
+// This file implements data structures and functions that relate to the
+// identity type.
+
+type identityDictionary struct {
+	mu   sync.Mutex
+	dict map[string]*resolvedIdentity
+}
+
+// Global dictionary of resolved identities
+
+var identityDict = identityDictionary{dict: map[string]*resolvedIdentity{}}
+
+type resolvedIdentity struct {
+	Module   *Module
+	Identity *Identity
+	//Children []*resolvedIdentity
+}
+
+func makeResolvedIdentity(m *Module, i *Identity) (string, *resolvedIdentity) {
+	r := &resolvedIdentity{
+		Module:   m,
+		Identity: i,
+	}
+	prefix := RootNode(i).GetPrefix()
+	keyName := fmt.Sprintf("%s:%s", prefix, i.Name)
+	return keyName, r
+}
+
+func appendIfNotIn(ids []*Identity, chk *Identity) []*Identity {
+	for _, id := range ids {
+		if id == chk {
+			return ids
+		}
+	}
+	return append(ids, chk)
+}
+
+func learnChildren(r *Identity, ids []*Identity) []*Identity {
+	// Learn this child
+	ids = appendIfNotIn(ids, r)
+	// But if it doesn't have any children, then return
+	if r.Values == nil {
+		return ids
+	}
+	// Else iterate through them
+	for _, ch := range r.Values {
+		ids = learnChildren(ch, ids)
+	}
+	return ids
+}
+
+func findIdentityBase(baseStr string, mod *Module) (*resolvedIdentity, []error) {
+	var base *resolvedIdentity
+	var ok bool
+	var errs []error
+
+	basePrefix, baseName := getPrefix(baseStr)
+	rootPrefix := mod.GetPrefix()
+
+	switch basePrefix {
+	case "", rootPrefix:
+		// This is a local identity which is defined within the current
+		// module
+		keyName := fmt.Sprintf("%s:%s", rootPrefix, baseName)
+
+		base, ok = identityDict.dict[keyName]
+		if !ok {
+			errs = append(errs, fmt.Errorf("can't resolve the local base %s", baseStr))
+		}
+	default:
+		// This is an identity which is defined within another module
+		externalModule := FindModuleByPrefix(mod, basePrefix)
+		if externalModule == nil {
+			errs = append(errs, fmt.Errorf("can't find external module with prefix %s", basePrefix))
+		}
+
+		// Run through the identities within the remote module and find the
+		// one that matches the base that we have been specified.
+		for _, rid := range externalModule.Identities() {
+			if rid.Name == baseName {
+				key, _ := makeResolvedIdentity(externalModule, rid)
+				if id, ok := identityDict.dict[key]; ok {
+					base = id
+				} else {
+					errs = append(errs, fmt.Errorf("can't find base %s", baseStr))
+				}
+				break
+			}
+		}
+		// Error if we did not find the identity that had the name specified in
+		// the module it was expected to be in.
+		if base == nil {
+			errs = append(errs, fmt.Errorf("can't resolve remote base %s", baseStr))
+		}
+	}
+	return base, errs
+}
+
+func (ms *Modules) resolveIdentities() []error {
+
+	// We are inplace modifying this global, and hence we have a lock on it.
+	defer identityDict.mu.Unlock()
+	identityDict.mu.Lock()
+
+	var errs []error
+
+	// Across all modules, read the identity values that have been extracted
+	// from them, and compile them into a "fully resolved" map that mean that
+	// we can look them up based on the 'real' prefix of the module and the
+	// name of the identity.
+	for _, mod := range ms.Modules {
+		for _, i := range mod.Identities() {
+			keyName, r := makeResolvedIdentity(mod, i)
+			identityDict.dict[keyName] = r
+		}
+	}
+
+	// Determine which identities have a base statement, and link this to a
+	// fully resolved identity statement. The intention here is to make sure
+	// that the Children slice is fully populated with pointers to all identities
+	// that have a base, so that we can do inheritance of these later.
+	for _, i := range identityDict.dict {
+		if i.Identity.Base != nil {
+			// This identity inherits from another identity.
+
+			root := RootNode(i.Identity)
+			base, baseErr := findIdentityBase(i.Identity.Base.asString(), root)
+
+			if baseErr != nil {
+				errs = append(errs, errs...)
+				continue
+			}
+
+			// Append this value to the children of the base identity.
+			base.Identity.Values = append(base.Identity.Values, i.Identity)
+		}
+	}
+
+	// Do a final sweep through the identities to build up their children.
+	for _, i := range identityDict.dict {
+		newValues := []*Identity{}
+		for _, j := range i.Identity.Values {
+			newValues = learnChildren(j, newValues)
+		}
+		i.Identity.Values = newValues
+	}
+
+	return errs
+}

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -296,6 +296,52 @@ var treeTestCases = []*basicIdentityTestCase{
 			},
 		},
 	},
+	&basicIdentityTestCase{
+		in: []*modIn{
+			&modIn{
+				name: "base.yang",
+				content: `
+  module base4 {
+    namespace "urn:base";
+    prefix "base4";
+
+		identity BASE4;
+		identity CHILD4 {
+			base BASE4;
+		}
+
+		typedef t {
+			type identityref {
+				base BASE4;
+			}
+		}
+
+		leaf tref {
+			type t;
+		}
+  }
+        `},
+		},
+		out: &basicIdentityModOut{
+			modules: []string{"base4"},
+			identities: []*identityOut{
+				&identityOut{
+					idName: "BASE4",
+				},
+				&identityOut{
+					idName:   "CHILD4",
+					baseName: "BASE4",
+				},
+			},
+			idrefs: []*idrefOut{
+				&idrefOut{
+					module: "base4",
+					name:   "tref",
+					values: []string{"CHILD4"},
+				},
+			},
+		},
+	},
 }
 
 // TestIdentityTree - check inheritance of identities from local and remote

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -21,26 +21,35 @@ type modIn struct {
 	content string
 }
 
-type modOut struct {
+type basicIdentityModOut struct {
 	name       string
-	identities []*idOut
+	identities []*identityOut
+	modules    []string
+	idrefs     []*idrefOut
 }
 
-type idOut struct {
+type idrefOut struct {
+	module string
+	name   string
+	values []string
+}
+
+type identityOut struct {
 	idName   string
 	baseName string
+	values   []string
 }
 
-type testCase struct {
+type basicIdentityTestCase struct {
 	name string
 	in   []*modIn
-	out  *modOut
+	out  *basicIdentityModOut
 	err  string
 }
 
 // A set of test modules to parse as part of the test case.
-var testCases = []*testCase{
-	&testCase{
+var basicTestCases = []*basicIdentityTestCase{
+	&basicIdentityTestCase{
 		in: []*modIn{
 			&modIn{
 				name: "idtest-one",
@@ -53,17 +62,17 @@ module idtest-one {
 }
     `},
 		},
-		out: &modOut{
+		out: &basicIdentityModOut{
 			name: "idtest-one",
-			identities: []*idOut{
-				&idOut{
+			identities: []*identityOut{
+				&identityOut{
 					idName: "TEST_ID",
 				},
 			},
 		},
 		err: "tc1: could not resolve identities",
 	},
-	&testCase{
+	&basicIdentityTestCase{
 		in: []*modIn{
 			&modIn{
 				name: "idtest-two",
@@ -80,16 +89,16 @@ module idtest-two {
 }
     `},
 		},
-		out: &modOut{
+		out: &basicIdentityModOut{
 			name: "idtest-two",
-			identities: []*idOut{
-				&idOut{
+			identities: []*identityOut{
+				&identityOut{
 					idName: "TEST_ID",
 				},
-				&idOut{
+				&identityOut{
 					idName: "TEST_ID_TWO",
 				},
-				&idOut{
+				&identityOut{
 					idName:   "TEST_CHILD",
 					baseName: "TEST_ID",
 				},
@@ -100,7 +109,7 @@ module idtest-two {
 }
 
 func TestIdentityExtract(t *testing.T) {
-	for _, testCase := range testCases {
+	for _, testCase := range basicTestCases {
 		ms := NewModules()
 		for _, mod := range testCase.in {
 			_ = ms.Parse(mod.content, mod.name)
@@ -134,6 +143,286 @@ func TestIdentityExtract(t *testing.T) {
 				if identity.Base != nil {
 					t.Errorf("%s: identity had an unexpected base %s: %v", testCase.err,
 						identity.Name, identity.Base)
+				}
+			}
+		}
+	}
+}
+
+var treeTestCases = []*basicIdentityTestCase{
+	&basicIdentityTestCase{
+		in: []*modIn{
+			&modIn{
+				name: "base.yang",
+				content: `
+  module base {
+    namespace "urn:base";
+    prefix "base";
+
+    import remote { prefix "r"; }
+
+    identity LOCAL_REMOTE_BASE {
+      base r:REMOTE_BASE;
+    }
+  }
+        `},
+			&modIn{
+				name: "remote.yang",
+				content: `
+  module remote {
+    namespace "urn:remote";
+    prefix "remote";
+
+    identity REMOTE_BASE;
+  }
+      `},
+		},
+		out: &basicIdentityModOut{
+			modules: []string{"remote", "base"},
+			identities: []*identityOut{
+				&identityOut{
+					idName: "REMOTE_BASE",
+					values: []string{"LOCAL_REMOTE_BASE"},
+				},
+				&identityOut{
+					idName:   "LOCAL_REMOTE_BASE",
+					baseName: "r:REMOTE_BASE",
+				},
+			},
+		},
+	},
+	&basicIdentityTestCase{
+		in: []*modIn{
+			&modIn{
+				name: "base.yang",
+				content: `
+  module base {
+    namespace "urn:base";
+    prefix "base";
+
+    identity GREATGRANDFATHER;
+		identity GRANDFATHER {
+			base "GREATGRANDFATHER";
+		}
+		identity FATHER {
+			base "GRANDFATHER";
+		}
+		identity SON {
+			base "FATHER";
+		}
+		identity UNCLE {
+			base "GRANDFATHER";
+		}
+		identity BROTHER {
+			base "FATHER";
+		}
+		identity GREATUNCLE {
+			base "GRANDFATHER";
+		}
+  }
+        `},
+		},
+		out: &basicIdentityModOut{
+			modules: []string{"base"},
+			identities: []*identityOut{
+				&identityOut{
+					idName: "GREATGRANDFATHER",
+					values: []string{"GRANDFATHER", "FATHER", "UNCLE", "SON", "BROTHER"},
+				},
+				&identityOut{
+					idName:   "GRANDFATHER",
+					baseName: "GREATGRANDFATHER",
+					values:   []string{"FATHER", "UNCLE", "SON", "BROTHER"},
+				},
+				&identityOut{
+					idName:   "FATHER",
+					baseName: "GRANDFATHER",
+					values:   []string{"SON", "BROTHER"},
+				},
+				&identityOut{
+					idName:   "UNCLE",
+					baseName: "GRANDFATHER",
+				},
+				&identityOut{
+					idName:   "SON",
+					baseName: "FATHER",
+				},
+				&identityOut{
+					idName:   "BROTHER",
+					baseName: "FATHER",
+				},
+			},
+		},
+	},
+	&basicIdentityTestCase{
+		in: []*modIn{
+			&modIn{
+				name: "base.yang",
+				content: `
+  module base {
+    namespace "urn:base";
+    prefix "base";
+
+		identity BASE;
+		identity NOTBASE {
+			base BASE;
+		}
+
+		leaf idref {
+			type identityref {
+				base "BASE";
+			}
+		}
+  }
+        `},
+		},
+		out: &basicIdentityModOut{
+			modules: []string{"base"},
+			identities: []*identityOut{
+				&identityOut{
+					idName: "BASE",
+				},
+				&identityOut{
+					idName:   "NOTBASE",
+					baseName: "BASE",
+				},
+			},
+			idrefs: []*idrefOut{
+				&idrefOut{
+					module: "base",
+					name:   "idref",
+					values: []string{"NOTBASE"},
+				},
+			},
+		},
+	},
+}
+
+// TestIdentityTree - check inheritance of identities from local and remote
+// sources. The Values of an Identity correspond to the values that are
+// referenced by that identity, which need to be inherited.
+func TestIdentityTree(t *testing.T) {
+	for _, testCase := range treeTestCases {
+		ms := NewModules()
+
+		for _, mod := range testCase.in {
+			_ = ms.Parse(mod.content, mod.name)
+		}
+
+		if errs := ms.Process(); len(errs) != 0 {
+			t.Errorf("couldn't process modules: %v", errs)
+			continue
+		}
+
+		identityValues := make(map[string][]string)
+		var foundIdentities []*Identity
+
+		if testCase.out == nil {
+			continue
+		}
+
+		// Go through and find all the identities and values for later comparison
+		for _, mn := range testCase.out.modules {
+			m, errs := ms.GetModule(mn)
+			if errs != nil {
+				t.Errorf("couldn't find expected module: %v", errs)
+			}
+			for _, i := range m.Identities {
+				foundIdentities = append(foundIdentities, i)
+				identityValues[i.Name] = make([]string, 0)
+				for _, j := range i.Values {
+					identityValues[i.Name] = append(identityValues[i.Name], j.Name)
+				}
+			}
+		}
+
+		// For each of the test cases, go through and compare whether we can find
+		// the identity, and the relevant base if one exists.
+		for _, tc := range testCase.out.identities {
+			nMatch := false
+			//vMatch := false
+			bMatch := 0
+			if tc.baseName != "" {
+				bMatch = -1
+			}
+
+			for _, fid := range foundIdentities {
+				if fid.Name == tc.idName {
+					nMatch = true
+					if bMatch < 0 && fid.Base != nil {
+						if fid.Base.Name == tc.baseName {
+							bMatch = 1
+						}
+					}
+					if tc.values != nil {
+						// Need to check values - create a map keyed by value with a bool
+						// as the value, we set this to true when we find the value, and
+						// then check for any values that are false.
+						rem := make(map[string]bool)
+						for _, v := range tc.values {
+							rem[v] = false
+						}
+
+						for _, v := range fid.Values {
+							if _, ok := rem[v.Name]; ok {
+								rem[v.Name] = true
+							}
+						}
+
+						for k, v := range rem {
+							if v == false {
+								t.Errorf("unable to find value %s for %s", k, tc.idName)
+							}
+						}
+					}
+				}
+			}
+
+			if nMatch == false {
+				t.Errorf("couldn't find identity %s", tc.idName)
+			}
+			if bMatch < 0 {
+				t.Errorf("couldn't find identity %s base %s", tc.idName, tc.baseName)
+			}
+		}
+
+		// Check the identityrefs that we have been asked to check and test
+		// whether the identity pointer is set up correctly.
+		if testCase.out.idrefs != nil {
+			for _, tidr := range testCase.out.idrefs {
+				mod, errs := ms.GetModule(tidr.module)
+				if errs != nil {
+					t.Errorf("can't find module %s for idref %s", tidr.module, tidr.name)
+					continue
+				}
+				if leaf, ok := mod.Dir[tidr.name]; ok {
+					tMap := make(map[string]bool)
+					for _, v := range tidr.values {
+						tMap[v] = false
+					}
+
+					if leaf.Type == nil || leaf.Type.IdentityBase == nil ||
+						leaf.Type.IdentityBase.Values == nil {
+						t.Errorf("identityref leaf %s was not properly formed", tidr.name)
+					}
+
+					for _, v := range leaf.Type.IdentityBase.Values {
+						if _, ok := tMap[v.Name]; ok {
+							tMap[v.Name] = true
+						} else {
+							t.Errorf("couldn't find identity value %s in base identity", v)
+						}
+					}
+
+					for k, v := range tMap {
+						if v == false {
+							t.Errorf("couldn't find identty value %s from base identity of %s",
+								k, tidr.name)
+						}
+					}
+				} else {
+					t.Errorf("couldn't find identityref leaf %s in module %s", tidr.module,
+						tidr.name)
 				}
 			}
 		}

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -59,7 +59,7 @@ var basicTestCases = []identityTestCase{
 
 					  identity TEST_ID;
 					}
-    `},
+    	`},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-one", name: "TEST_ID"},
@@ -82,7 +82,7 @@ var basicTestCases = []identityTestCase{
 					    base TEST_ID;
 					  }
 					}
-    `},
+    	`},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-two", name: "TEST_ID"},
@@ -157,7 +157,7 @@ var treeTestCases = []identityTestCase{
 				      base r:REMOTE_BASE;
 				    }
 				  }
-        `},
+      `},
 			inputModule{
 				name: "remote.yang",
 				content: `
@@ -212,7 +212,7 @@ var treeTestCases = []identityTestCase{
 							base "GREATGRANDFATHER";
 						}
 				  }
-        `},
+      `},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -276,7 +276,7 @@ var treeTestCases = []identityTestCase{
 							}
 						}
 				  }
-        `},
+      `},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -322,7 +322,7 @@ var treeTestCases = []identityTestCase{
 							type t;
 						}
 				  }
-        `},
+      `},
 		},
 		identities: []identityOut{
 			identityOut{

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -59,7 +59,7 @@ var basicTestCases = []identityTestCase{
 
 					  identity TEST_ID;
 					}
-    	`},
+    	    `},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-one", name: "TEST_ID"},
@@ -82,7 +82,7 @@ var basicTestCases = []identityTestCase{
 					    base TEST_ID;
 					  }
 					}
-    	`},
+    			`},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-two", name: "TEST_ID"},
@@ -157,7 +157,7 @@ var treeTestCases = []identityTestCase{
 				      base r:REMOTE_BASE;
 				    }
 				  }
-      `},
+      		`},
 			inputModule{
 				name: "remote.yang",
 				content: `
@@ -212,7 +212,7 @@ var treeTestCases = []identityTestCase{
 							base "GREATGRANDFATHER";
 						}
 				  }
-      `},
+      		`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -276,7 +276,7 @@ var treeTestCases = []identityTestCase{
 							}
 						}
 				  }
-      `},
+      		`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -322,7 +322,7 @@ var treeTestCases = []identityTestCase{
 							type t;
 						}
 				  }
-      `},
+      		`},
 		},
 		identities: []identityOut{
 			identityOut{

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -59,7 +59,7 @@ var basicTestCases = []identityTestCase{
 
 					  identity TEST_ID;
 					}
-    	    `},
+    	  `},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-one", name: "TEST_ID"},
@@ -82,7 +82,7 @@ var basicTestCases = []identityTestCase{
 					    base TEST_ID;
 					  }
 					}
-    			`},
+    		`},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-two", name: "TEST_ID"},
@@ -157,7 +157,7 @@ var treeTestCases = []identityTestCase{
 				      base r:REMOTE_BASE;
 				    }
 				  }
-      		`},
+      	`},
 			inputModule{
 				name: "remote.yang",
 				content: `
@@ -167,7 +167,7 @@ var treeTestCases = []identityTestCase{
 
 				    identity REMOTE_BASE;
 				  }
-      `},
+      	`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -212,7 +212,7 @@ var treeTestCases = []identityTestCase{
 							base "GREATGRANDFATHER";
 						}
 				  }
-      		`},
+      	`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -276,7 +276,7 @@ var treeTestCases = []identityTestCase{
 							}
 						}
 				  }
-      		`},
+      	`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -322,7 +322,7 @@ var treeTestCases = []identityTestCase{
 							type t;
 						}
 				  }
-      		`},
+      	`},
 		},
 		identities: []identityOut{
 			identityOut{

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -53,12 +53,12 @@ var basicTestCases = []identityTestCase{
 			inputModule{
 				name: "idtest-one",
 				content: `
-module idtest-one {
-  namespace "urn:idone";
-  prefix "idone";
+					module idtest-one {
+					  namespace "urn:idone";
+					  prefix "idone";
 
-  identity TEST_ID;
-}
+					  identity TEST_ID;
+					}
     `},
 		},
 		identities: []identityOut{
@@ -72,16 +72,16 @@ module idtest-one {
 			inputModule{
 				name: "idtest-two",
 				content: `
-module idtest-two {
-  namespace "urn:idtwo";
-  prefix "idone";
+					module idtest-two {
+					  namespace "urn:idtwo";
+					  prefix "idone";
 
-  identity TEST_ID;
-  identity TEST_ID_TWO;
-  identity TEST_CHILD {
-    base TEST_ID;
-  }
-}
+					  identity TEST_ID;
+					  identity TEST_ID_TWO;
+					  identity TEST_CHILD {
+					    base TEST_ID;
+					  }
+					}
     `},
 		},
 		identities: []identityOut{
@@ -147,26 +147,26 @@ var treeTestCases = []identityTestCase{
 			inputModule{
 				name: "base.yang",
 				content: `
-  module base {
-    namespace "urn:base";
-    prefix "base";
+				  module base {
+				    namespace "urn:base";
+				    prefix "base";
 
-    import remote { prefix "r"; }
+				    import remote { prefix "r"; }
 
-    identity LOCAL_REMOTE_BASE {
-      base r:REMOTE_BASE;
-    }
-  }
+				    identity LOCAL_REMOTE_BASE {
+				      base r:REMOTE_BASE;
+				    }
+				  }
         `},
 			inputModule{
 				name: "remote.yang",
 				content: `
-  module remote {
-    namespace "urn:remote";
-    prefix "remote";
+				  module remote {
+				    namespace "urn:remote";
+				    prefix "remote";
 
-    identity REMOTE_BASE;
-  }
+				    identity REMOTE_BASE;
+				  }
       `},
 		},
 		identities: []identityOut{
@@ -188,30 +188,30 @@ var treeTestCases = []identityTestCase{
 			inputModule{
 				name: "base.yang",
 				content: `
-  module base {
-    namespace "urn:base";
-    prefix "base";
+				  module base {
+				    namespace "urn:base";
+				    prefix "base";
 
-    identity GREATGRANDFATHER;
-		identity GRANDFATHER {
-			base "GREATGRANDFATHER";
-		}
-		identity FATHER {
-			base "GRANDFATHER";
-		}
-		identity SON {
-			base "FATHER";
-		}
-		identity UNCLE {
-			base "GRANDFATHER";
-		}
-		identity BROTHER {
-			base "FATHER";
-		}
-		identity GREATUNCLE {
-			base "GREATGRANDFATHER";
-		}
-  }
+				    identity GREATGRANDFATHER;
+						identity GRANDFATHER {
+							base "GREATGRANDFATHER";
+						}
+						identity FATHER {
+							base "GRANDFATHER";
+						}
+						identity SON {
+							base "FATHER";
+						}
+						identity UNCLE {
+							base "GRANDFATHER";
+						}
+						identity BROTHER {
+							base "FATHER";
+						}
+						identity GREATUNCLE {
+							base "GREATGRANDFATHER";
+						}
+				  }
         `},
 		},
 		identities: []identityOut{
@@ -261,21 +261,21 @@ var treeTestCases = []identityTestCase{
 			inputModule{
 				name: "base.yang",
 				content: `
-  module base {
-    namespace "urn:base";
-    prefix "base";
+				  module base {
+				    namespace "urn:base";
+				    prefix "base";
 
-		identity BASE;
-		identity NOTBASE {
-			base BASE;
-		}
+						identity BASE;
+						identity NOTBASE {
+							base BASE;
+						}
 
-		leaf idref {
-			type identityref {
-				base "BASE";
-			}
-		}
-  }
+						leaf idref {
+							type identityref {
+								base "BASE";
+							}
+						}
+				  }
         `},
 		},
 		identities: []identityOut{
@@ -303,25 +303,25 @@ var treeTestCases = []identityTestCase{
 			inputModule{
 				name: "base.yang",
 				content: `
-  module base4 {
-    namespace "urn:base";
-    prefix "base4";
+				  module base4 {
+				    namespace "urn:base";
+				    prefix "base4";
 
-		identity BASE4;
-		identity CHILD4 {
-			base BASE4;
-		}
+						identity BASE4;
+						identity CHILD4 {
+							base BASE4;
+						}
 
-		typedef t {
-			type identityref {
-				base BASE4;
-			}
-		}
+						typedef t {
+							type identityref {
+								base BASE4;
+							}
+						}
 
-		leaf tref {
-			type t;
-		}
-  }
+						leaf tref {
+							type t;
+						}
+				  }
         `},
 		},
 		identities: []identityOut{

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -59,7 +59,7 @@ var basicTestCases = []identityTestCase{
 
 					  identity TEST_ID;
 					}
-    	  `},
+				`},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-one", name: "TEST_ID"},
@@ -82,7 +82,7 @@ var basicTestCases = []identityTestCase{
 					    base TEST_ID;
 					  }
 					}
-    		`},
+				`},
 		},
 		identities: []identityOut{
 			identityOut{module: "idtest-two", name: "TEST_ID"},
@@ -157,7 +157,7 @@ var treeTestCases = []identityTestCase{
 				      base r:REMOTE_BASE;
 				    }
 				  }
-      	`},
+				`},
 			inputModule{
 				name: "remote.yang",
 				content: `
@@ -167,7 +167,7 @@ var treeTestCases = []identityTestCase{
 
 				    identity REMOTE_BASE;
 				  }
-      	`},
+				`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -212,7 +212,7 @@ var treeTestCases = []identityTestCase{
 							base "GREATGRANDFATHER";
 						}
 				  }
-      	`},
+				`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -276,7 +276,7 @@ var treeTestCases = []identityTestCase{
 							}
 						}
 				  }
-      	`},
+				`},
 		},
 		identities: []identityOut{
 			identityOut{
@@ -322,7 +322,7 @@ var treeTestCases = []identityTestCase{
 							type t;
 						}
 				  }
-      	`},
+				`},
 		},
 		identities: []identityOut{
 			identityOut{

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -14,7 +14,10 @@
 
 package yang
 
-import "testing"
+import (
+  "testing"
+  "reflect"
+)
 
 type modIn struct {
 	name    string
@@ -23,9 +26,9 @@ type modIn struct {
 
 type basicIdentityModOut struct {
 	name       string
-	identities []*identityOut
+	identities []identityOut
 	modules    []string
-	idrefs     []*idrefOut
+	idrefs     []idrefOut
 }
 
 type idrefOut struct {
@@ -42,16 +45,16 @@ type identityOut struct {
 
 type basicIdentityTestCase struct {
 	name string
-	in   []*modIn
-	out  *basicIdentityModOut
+	in   []modIn
+	out  basicIdentityModOut
 	err  string
 }
 
 // A set of test modules to parse as part of the test case.
-var basicTestCases = []*basicIdentityTestCase{
-	&basicIdentityTestCase{
-		in: []*modIn{
-			&modIn{
+var basicTestCases = []basicIdentityTestCase{
+	basicIdentityTestCase{
+		in: []modIn{
+			modIn{
 				name: "idtest-one",
 				content: `
 module idtest-one {
@@ -62,19 +65,19 @@ module idtest-one {
 }
     `},
 		},
-		out: &basicIdentityModOut{
+		out: basicIdentityModOut{
 			name: "idtest-one",
-			identities: []*identityOut{
-				&identityOut{
+			identities: []identityOut{
+				identityOut{
 					idName: "TEST_ID",
 				},
 			},
 		},
 		err: "tc1: could not resolve identities",
 	},
-	&basicIdentityTestCase{
-		in: []*modIn{
-			&modIn{
+	basicIdentityTestCase{
+		in: []modIn{
+			modIn{
 				name: "idtest-two",
 				content: `
 module idtest-two {
@@ -89,16 +92,16 @@ module idtest-two {
 }
     `},
 		},
-		out: &basicIdentityModOut{
+		out: basicIdentityModOut{
 			name: "idtest-two",
-			identities: []*identityOut{
-				&identityOut{
+			identities: []identityOut{
+				identityOut{
 					idName: "TEST_ID",
 				},
-				&identityOut{
+				identityOut{
 					idName: "TEST_ID_TWO",
 				},
-				&identityOut{
+				identityOut{
 					idName:   "TEST_CHILD",
 					baseName: "TEST_ID",
 				},
@@ -149,10 +152,10 @@ func TestIdentityExtract(t *testing.T) {
 	}
 }
 
-var treeTestCases = []*basicIdentityTestCase{
-	&basicIdentityTestCase{
-		in: []*modIn{
-			&modIn{
+var treeTestCases = []basicIdentityTestCase{
+	basicIdentityTestCase{
+		in: []modIn{
+			modIn{
 				name: "base.yang",
 				content: `
   module base {
@@ -166,7 +169,7 @@ var treeTestCases = []*basicIdentityTestCase{
     }
   }
         `},
-			&modIn{
+			modIn{
 				name: "remote.yang",
 				content: `
   module remote {
@@ -177,23 +180,23 @@ var treeTestCases = []*basicIdentityTestCase{
   }
       `},
 		},
-		out: &basicIdentityModOut{
+		out: basicIdentityModOut{
 			modules: []string{"remote", "base"},
-			identities: []*identityOut{
-				&identityOut{
+			identities: []identityOut{
+				identityOut{
 					idName: "REMOTE_BASE",
 					values: []string{"LOCAL_REMOTE_BASE"},
 				},
-				&identityOut{
+				identityOut{
 					idName:   "LOCAL_REMOTE_BASE",
 					baseName: "r:REMOTE_BASE",
 				},
 			},
 		},
 	},
-	&basicIdentityTestCase{
-		in: []*modIn{
-			&modIn{
+	basicIdentityTestCase{
+		in: []modIn{
+			modIn{
 				name: "base.yang",
 				content: `
   module base {
@@ -222,41 +225,41 @@ var treeTestCases = []*basicIdentityTestCase{
   }
         `},
 		},
-		out: &basicIdentityModOut{
+		out: basicIdentityModOut{
 			modules: []string{"base"},
-			identities: []*identityOut{
-				&identityOut{
+			identities: []identityOut{
+				identityOut{
 					idName: "GREATGRANDFATHER",
 					values: []string{"GRANDFATHER", "FATHER", "UNCLE", "SON", "BROTHER"},
 				},
-				&identityOut{
+				identityOut{
 					idName:   "GRANDFATHER",
 					baseName: "GREATGRANDFATHER",
 					values:   []string{"FATHER", "UNCLE", "SON", "BROTHER"},
 				},
-				&identityOut{
+				identityOut{
 					idName:   "FATHER",
 					baseName: "GRANDFATHER",
 					values:   []string{"SON", "BROTHER"},
 				},
-				&identityOut{
+				identityOut{
 					idName:   "UNCLE",
 					baseName: "GRANDFATHER",
 				},
-				&identityOut{
+				identityOut{
 					idName:   "SON",
 					baseName: "FATHER",
 				},
-				&identityOut{
+				identityOut{
 					idName:   "BROTHER",
 					baseName: "FATHER",
 				},
 			},
 		},
 	},
-	&basicIdentityTestCase{
-		in: []*modIn{
-			&modIn{
+	basicIdentityTestCase{
+		in: []modIn{
+			modIn{
 				name: "base.yang",
 				content: `
   module base {
@@ -276,19 +279,19 @@ var treeTestCases = []*basicIdentityTestCase{
   }
         `},
 		},
-		out: &basicIdentityModOut{
+		out: basicIdentityModOut{
 			modules: []string{"base"},
-			identities: []*identityOut{
-				&identityOut{
+			identities: []identityOut{
+				identityOut{
 					idName: "BASE",
 				},
-				&identityOut{
+				identityOut{
 					idName:   "NOTBASE",
 					baseName: "BASE",
 				},
 			},
-			idrefs: []*idrefOut{
-				&idrefOut{
+			idrefs: []idrefOut{
+				idrefOut{
 					module: "base",
 					name:   "idref",
 					values: []string{"NOTBASE"},
@@ -296,9 +299,9 @@ var treeTestCases = []*basicIdentityTestCase{
 			},
 		},
 	},
-	&basicIdentityTestCase{
-		in: []*modIn{
-			&modIn{
+	basicIdentityTestCase{
+		in: []modIn{
+			modIn{
 				name: "base.yang",
 				content: `
   module base4 {
@@ -322,19 +325,19 @@ var treeTestCases = []*basicIdentityTestCase{
   }
         `},
 		},
-		out: &basicIdentityModOut{
+		out: basicIdentityModOut{
 			modules: []string{"base4"},
-			identities: []*identityOut{
-				&identityOut{
+			identities: []identityOut{
+				identityOut{
 					idName: "BASE4",
 				},
-				&identityOut{
+				identityOut{
 					idName:   "CHILD4",
 					baseName: "BASE4",
 				},
 			},
-			idrefs: []*idrefOut{
-				&idrefOut{
+			idrefs: []idrefOut{
+				idrefOut{
 					module: "base4",
 					name:   "tref",
 					values: []string{"CHILD4"},
@@ -363,7 +366,7 @@ func TestIdentityTree(t *testing.T) {
 		identityValues := make(map[string][]string)
 		var foundIdentities []*Identity
 
-		if testCase.out == nil {
+    if reflect.DeepEqual(testCase.out, basicIdentityModOut{}){
 			continue
 		}
 

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -406,6 +406,9 @@ func TestIdentityTree(t *testing.T) {
 						t.Errorf("identityref leaf %s was not properly formed", tidr.name)
 					}
 
+					// Check whether the identityref leaf had an Identity within the
+					// Values that corresponds to the one that we were asked to retrieve
+					// within the test data.
 					for _, v := range leaf.Type.IdentityBase.Values {
 						if _, ok := tMap[v.Name]; ok {
 							tMap[v.Name] = true
@@ -414,12 +417,31 @@ func TestIdentityTree(t *testing.T) {
 						}
 					}
 
+					// Check whether GetValue returns the defined value
+					for _, k := range tidr.values {
+						if v := leaf.Type.IdentityBase.GetValue(k); v == nil {
+							t.Errorf("couldn't retrieve identity value %s with GetValue from %s",
+								k, leaf.Type.IdentityBase.Name)
+						}
+					}
+
+					// Check whether IsDefined returns the right result.
+					for _, k := range tidr.values {
+						if c := leaf.Type.IdentityBase.IsDefined(k); !c {
+							t.Errorf("couldn't retrieve identity value %s with IsDefiend from %s",
+								k, leaf.Type.IdentityBase.Name)
+						}
+					}
+
+					// If any entries are false in the tMap, this means that it did not
+					// match when we walked through the values that are defined.
 					for k, v := range tMap {
 						if v == false {
-							t.Errorf("couldn't find identty value %s from base identity of %s",
+							t.Errorf("couldn't find identity value %s from base identity of %s",
 								k, tidr.name)
 						}
 					}
+
 				} else {
 					t.Errorf("couldn't find identityref leaf %s in module %s", tidr.module,
 						tidr.name)

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yang
+
+import "testing"
+
+type modIn struct {
+	name    string
+	content string
+}
+
+type modOut struct {
+	name       string
+	identities []*idOut
+}
+
+type idOut struct {
+	idName   string
+	baseName string
+}
+
+type testCase struct {
+	name string
+	in   []*modIn
+	out  *modOut
+	err  string
+}
+
+// A set of test modules to parse as part of the test case.
+var testCases = []*testCase{
+	&testCase{
+		in: []*modIn{
+			&modIn{
+				name: "idtest-one",
+				content: `
+module idtest-one {
+  namespace "urn:idone";
+  prefix "idone";
+
+  identity TEST_ID;
+}
+    `},
+		},
+		out: &modOut{
+			name: "idtest-one",
+			identities: []*idOut{
+				&idOut{
+					idName: "TEST_ID",
+				},
+			},
+		},
+		err: "tc1: could not resolve identities",
+	},
+	&testCase{
+		in: []*modIn{
+			&modIn{
+				name: "idtest-two",
+				content: `
+module idtest-two {
+  namespace "urn:idtwo";
+  prefix "idone";
+
+  identity TEST_ID;
+  identity TEST_ID_TWO;
+  identity TEST_CHILD {
+    base TEST_ID;
+  }
+}
+    `},
+		},
+		out: &modOut{
+			name: "idtest-two",
+			identities: []*idOut{
+				&idOut{
+					idName: "TEST_ID",
+				},
+				&idOut{
+					idName: "TEST_ID_TWO",
+				},
+				&idOut{
+					idName:   "TEST_CHILD",
+					baseName: "TEST_ID",
+				},
+			},
+		},
+		err: "could not resolve identities",
+	},
+}
+
+func TestIdentityExtract(t *testing.T) {
+	for _, testCase := range testCases {
+		ms := NewModules()
+		for _, mod := range testCase.in {
+			_ = ms.Parse(mod.content, mod.name)
+		}
+		parsedMod, err := ms.GetModule(testCase.out.name)
+
+		if err != nil {
+			t.Errorf("could not parse module: %s", testCase.out.name)
+			continue
+		}
+
+		identityNames := make(map[string]*Identity)
+		for _, id := range parsedMod.Identities {
+			identityNames[id.Name] = id
+		}
+
+		for _, expID := range testCase.out.identities {
+			identity, ok := identityNames[expID.idName]
+
+			if !ok {
+				t.Errorf("%s: couldn't find %s", testCase.err, expID.idName)
+				continue
+			}
+
+			if expID.baseName != "" {
+				if expID.baseName != identity.Base.Name {
+					t.Errorf("%s: couldn't resolve expected base %s", testCase.err,
+						expID.baseName)
+				}
+			} else {
+				if identity.Base != nil {
+					t.Errorf("%s: identity had an unexpected base %s: %v", testCase.err,
+						identity.Name, identity.Base)
+				}
+			}
+		}
+	}
+}

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -246,6 +246,9 @@ func (ms *Modules) process() []error {
 
 	// Append any errors found trying to resolve typedefs
 	errs = append(errs, resolveTypedefs()...)
+
+	errs = append(errs, ms.resolveIdentities()...)
+
 	return errs
 }
 
@@ -376,6 +379,7 @@ func (ms *Modules) include(m *Module) error {
 		if err := ms.include(im); err != nil {
 			return err
 		}
+
 		i.Module = im
 	}
 	return nil

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -244,10 +244,12 @@ func (ms *Modules) process() []error {
 		}
 	}
 
+	// Resolve identities before resolving typedefs, otherwise when we resolve a
+	// typedef that has an identityref within it, then the identity dictionary
+	// has not yet been built.
+	errs = append(errs, ms.resolveIdentities()...)
 	// Append any errors found trying to resolve typedefs
 	errs = append(errs, resolveTypedefs()...)
-
-	errs = append(errs, ms.resolveIdentities()...)
 
 	return errs
 }

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -144,8 +144,7 @@ func (t *Typedef) resolve() []error {
 		if idBase, err := RootNode(t).findIdentityBase(t.Type.IdentityBase.Name); err == nil {
 			y.IdentityBase = idBase.Identity
 		} else {
-			return []error{fmt.Errorf("Could not resolve identity base for typedef: %s",
-				t.Type.IdentityBase.Name)}
+			return []error{fmt.Errorf("Could not resolve identity base for typedef: %s", t.Type.IdentityBase.Name)}
 		}
 	}
 

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -141,7 +141,7 @@ func (t *Typedef) resolve() []error {
 
 	if t.Type.IdentityBase != nil {
 		// We need to copy over the IdentityBase statement if the type has one
-		if idBase, err := findIdentityBase(t.Type.IdentityBase.Name, RootNode(t)); err == nil {
+		if idBase, err := RootNode(t).findIdentityBase(t.Type.IdentityBase.Name); err == nil {
 			y.IdentityBase = idBase.Identity
 		} else {
 			return []error{fmt.Errorf("Could not resolve identity base for typedef: %s",
@@ -262,7 +262,7 @@ check:
 		}
 
 		root := RootNode(t.Parent)
-		resolvedBase, baseErr := findIdentityBase(t.IdentityBase.Name, root)
+		resolvedBase, baseErr := root.findIdentityBase(t.IdentityBase.Name)
 		if baseErr != nil {
 			errs = append(errs, baseErr...)
 			break

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -242,8 +242,16 @@ check:
 	case y.Kind == Yidentityref:
 		if t.IdentityBase == nil {
 			errs = append(errs, fmt.Errorf("%s: an identityref must specify a base", Source(t)))
+			break
 		}
-		y.IdentityBase = t.IdentityBase
+
+		root := RootNode(t.Parent)
+		resolvedBase, baseErr := findIdentityBase(t.IdentityBase.Name, root)
+		if baseErr != nil {
+			errs = append(errs, baseErr...)
+		}
+
+		y.IdentityBase = resolvedBase.Identity
 	}
 
 	if t.Range != nil {

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -40,7 +40,7 @@ type typeDictionary struct {
 // process them completely independently of eachother.
 var typeDict = typeDictionary{dict: map[Node]map[string]*Typedef{}}
 
-// add adds an entry to the typeDictorary d.
+// add adds an entry to the typeDictionary d.
 func (d *typeDictionary) add(n Node, name string, td *Typedef) {
 	defer d.mu.Unlock()
 	d.mu.Lock()
@@ -214,6 +214,7 @@ check:
 		return []error{fmt.Errorf("%s: no YangType defined for %s %s", Source(td), source, td.Name)}
 	}
 	y := *td.YangType
+
 	y.Base = td.Type
 	t.YangType = &y
 
@@ -238,6 +239,11 @@ check:
 		y.FractionDigits = int(i)
 	case t.FractionDigits != nil:
 		errs = append(errs, fmt.Errorf("%s: fraction-digits only allowed for decimal64 values", Source(t)))
+	case y.Kind == Yidentityref:
+		if t.IdentityBase == nil {
+			errs = append(errs, fmt.Errorf("%s: an identityref must specify a base", Source(t)))
+		}
+		y.IdentityBase = t.IdentityBase
 	}
 
 	if t.Range != nil {

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -249,10 +249,8 @@ type YangType struct {
 	Name string
 	Kind TypeKind // Ynone if not a base type
 	// Base represents the base Type if this is a derived type
-	Base *Type `json:"-"` // dervied from
-	// IdentityBase represents the "base" statement of an Identityref type.
-	// It is distinct from the Base specified above.
-	IdentityBase     *Identity
+	Base *Type `json:"-"`        // Base type for non-builtin types
+	IdentityBase     *Identity   // Base statement for a type using identityref
 	Root             *YangType   `json:"-"` // root of this type that is the same
 	Bit              *EnumType   // bit position, "status" is lost
 	Enum             *EnumType   // enum name to value, "status" is lost

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -246,10 +246,9 @@ func (e *EnumType) ValueMap() map[int64]string {
 // refer to either a builtin type or type specified with typedef.  Not
 // all fields in YangType are used for all types.
 type YangType struct {
-	Name string
-	Kind TypeKind // Ynone if not a base type
-	// Base represents the base Type if this is a derived type
-	Base *Type `json:"-"`        // Base type for non-builtin types
+	Name             string
+	Kind             TypeKind    // Ynone if not a base type
+	Base             *Type       `json:"-"` // Base type for non-builtin types
 	IdentityBase     *Identity   // Base statement for a type using identityref
 	Root             *YangType   `json:"-"` // root of this type that is the same
 	Bit              *EnumType   // bit position, "status" is lost

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -246,9 +246,13 @@ func (e *EnumType) ValueMap() map[int64]string {
 // refer to either a builtin type or type specified with typedef.  Not
 // all fields in YangType are used for all types.
 type YangType struct {
-	Name             string
-	Kind             TypeKind    // Ynone if not a base type
-	Base             *Type       `json:"-"` // dervied from
+	Name string
+	Kind TypeKind // Ynone if not a base type
+	// Base represents the base Type if this is a derived type
+	Base *Type `json:"-"` // dervied from
+	// IdentityBase represents the "base" statement of an Identityref type.
+	// It is distinct from the Base specified above.
+	IdentityBase     *Value
 	Root             *YangType   `json:"-"` // root of this type that is the same
 	Bit              *EnumType   // bit position, "status" is lost
 	Enum             *EnumType   // enum name to value, "status" is lost

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -252,7 +252,7 @@ type YangType struct {
 	Base *Type `json:"-"` // dervied from
 	// IdentityBase represents the "base" statement of an Identityref type.
 	// It is distinct from the Base specified above.
-	IdentityBase     *Value
+	IdentityBase     *Identity
 	Root             *YangType   `json:"-"` // root of this type that is the same
 	Bit              *EnumType   // bit position, "status" is lost
 	Enum             *EnumType   // enum name to value, "status" is lost

--- a/pkg/yang/types_test.go
+++ b/pkg/yang/types_test.go
@@ -50,6 +50,12 @@ func TestTypeResolve(t *testing.T) {
 		},
 		{
 			in: &Type{
+				Name: "identityref",
+			},
+			err: "unknown: an identityref must specify a base",
+		},
+		{
+			in: &Type{
 				Name:           "decimal64",
 				FractionDigits: &Value{Name: "42"},
 			},

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -148,12 +148,13 @@ func (s *Module) Kind() string {
 	}
 	return "module"
 }
-func (s *Module) ParentNode() Node       { return s.Parent }
-func (s *Module) NName() string          { return s.Name }
-func (s *Module) Statement() *Statement  { return s.Source }
-func (s *Module) Exts() []*Statement     { return s.Extensions }
-func (s *Module) Groupings() []*Grouping { return s.Grouping }
-func (s *Module) Typedefs() []*Typedef   { return s.Typedef }
+func (s *Module) ParentNode() Node        { return s.Parent }
+func (s *Module) NName() string           { return s.Name }
+func (s *Module) Statement() *Statement   { return s.Source }
+func (s *Module) Exts() []*Statement      { return s.Extensions }
+func (s *Module) Groupings() []*Grouping  { return s.Grouping }
+func (s *Module) Typedefs() []*Typedef    { return s.Typedef }
+func (s *Module) Identities() []*Identity { return s.Identity }
 
 // Current returns the most recent revision of this module, or "" if the module
 // has no revisions.
@@ -306,7 +307,7 @@ type Type struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
-	Base            *Value     `yang:"base"` // Name == identityref
+	IdentityBase    *Value     `yang:"base"` // Name == identityref
 	Bit             []*Bit     `yang:"bit"`
 	Enum            []*Enum    `yang:"enum"`
 	FractionDigits  *Value     `yang:"fraction-digits"` // Name == decimal64

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -782,6 +782,11 @@ func (s *Identity) NName() string         { return s.Name }
 func (s *Identity) Statement() *Statement { return s.Source }
 func (s *Identity) Exts() []*Statement    { return s.Extensions }
 
+// PrefixedName returns the prefix-qualified name for the identity
+func (s *Identity) PrefixedName() string {
+	return fmt.Sprintf("%s:%s", RootNode(s).GetPrefix(), s.Name)
+}
+
 // IsDefined behaves the same as the implementation for Enum - it returns
 // true if an identity with the name is defined within the Values of the
 // identity

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -138,7 +138,8 @@ type Module struct {
 	// as the schema tree has multiple root elements.
 	// typedefs is a list of all top level typedefs in this
 	// module.
-	modules  *Modules
+	modules *Modules
+
 	typedefs map[string]*Typedef
 }
 
@@ -772,6 +773,7 @@ type Identity struct {
 	Description *Value `yang:"description"`
 	Reference   *Value `yang:"reference"`
 	Status      *Value `yang:"status"`
+	Values      []*Identity
 }
 
 func (Identity) Kind() string             { return "identity" }

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -782,6 +782,27 @@ func (s *Identity) NName() string         { return s.Name }
 func (s *Identity) Statement() *Statement { return s.Source }
 func (s *Identity) Exts() []*Statement    { return s.Extensions }
 
+// IsDefined behaves the same as the implementation for Enum - it returns
+// true if an identity with the name is defined within the Values of the
+// identity
+func (s *Identity) IsDefined(name string) bool {
+	if s.GetValue(name) != nil {
+		return true
+	}
+	return false
+}
+
+// GetValue returns a pointer to the identity with name "name" that is within
+// the values of the identity
+func (s *Identity) GetValue(name string) *Identity {
+	for _, v := range s.Values {
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
 // An Extension is defined in: http://tools.ietf.org/html/rfc6020#section-7.17
 type Extension struct {
 	Name       string       `yang:"Name,nomerge"`


### PR DESCRIPTION
This PR covers functionality built on top of #23. In addition to determining the Identities that exist, this functionality resolves identities to their respective bases (including if there are multiple levels of inheritance). In addition, add support for `identityref` leaves to have `IdentityBase` populated with the relevant identity - the types that are valid for that `identityref` to refer to are then populated in `IdentityBase.Values`.

Minor other fixes - adding test case coverage, and supporting `identityref` within a `typedef` also included.