### PR TITLE
Add tests for IsDefined and GetValue for Identity.

### DIFF
--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -394,6 +394,25 @@ func TestIdentityTree(t *testing.T) {
 
 			for _, val := range chkID.values {
 				valueMap[val] = false
+				// Check that IsDefined returns the right result
+				if !foundID.IsDefined(val) {
+					t.Errorf("Couldn't find defined value %s  for %s", val, chkID.name)
+				}
+
+				// Check that GetValue returns the right Identity
+				idval := foundID.GetValue(val)
+				if idval == nil {
+					t.Errorf("Couldn't GetValue(%s) for %s", val, chkID.name)
+				}
+			}
+
+			// Ensure that IsDefined does not return false positives
+			if foundID.IsDefined("DoesNotExist") {
+				t.Errorf("Non-existent value IsDefined for %s", foundID.Name)
+			}
+
+			if foundID.GetValue("DoesNotExist") != nil {
+				t.Errorf("Non-existent value GetValue not nil for %s", foundID.Name)
 			}
 
 			for _, chkv := range foundID.Values {


### PR DESCRIPTION
This PR adds some missing tests for the methods on the Identity struct which went missing when refactoring the test structure there. They didn't require any changes to the methods themselves, but are included so we can catch any future regression.

```
 * (M) pkg/yang/identity_test.go:
    - Add missing tests for the IsDefined and GetValue methods on
      identity including checking that non-existent values are not
      erroneously reported as existing.
```