### PR TITLE
yang: Entry: support Leaf default values

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -70,6 +70,7 @@ type Entry struct {
 	Node        Node      // the base node this Entry was derived from.
 	Name        string    // our name, same as the key in our parent Dirs
 	Description string    // description from node, if any
+	Default     string    // default from node, if any
 	Errors      []error   // list of errors encounterd on this node
 	Kind        EntryKind // kind of Entry
 	Config      TriState  // config state of this entry, if known
@@ -370,6 +371,9 @@ func ToEntry(n Node) (e *Entry) {
 		if s.Description != nil {
 			e.Description = s.Description.Name
 		}
+		if s.Default != nil {
+			e.Default = s.Default.Name
+		}
 		e.Type = s.Type.YangType
 		entryCache[n] = e
 		e.Config, err = configValue(s.Config)
@@ -563,12 +567,12 @@ func ToEntry(n Node) (e *Entry) {
 
 		// Keywords that do not need to be handled as an Entry as they are added
 		// to other dictionaries.
-		case "typedef":
+		case "default",
+			"typedef":
 			continue
 		// TODO(borman): unimplemented keywords
 		case "belongs-to",
 			"contact",
-			"default",
 			"deviation",
 			"extension",
 			"feature",
@@ -904,4 +908,15 @@ func errorSort(errors []error) []error {
 		i++
 	}
 	return errors[:i]
+}
+
+// DefaultValue returns the schema default value for e, if any. If the leaf
+// has no explicit default, its type default (if any) will be used.
+func (e *Entry) DefaultValue() string {
+	if len(e.Default) > 0 {
+		return e.Default
+	} else if typ := e.Type; typ != nil {
+		return typ.Default
+	}
+	return ""
 }

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -285,7 +285,7 @@ module defaults {
 
   typedef string-default {
     type string;
-    default "typedef default string";
+    default "typedef default value";
   }
 
   grouping common {
@@ -297,7 +297,7 @@ module defaults {
     container common-withdefault {
       leaf string {
         type string;
-        default "default string";
+        default "default value";
       }
     }
     container common-typedef-withdefault {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -17,6 +17,7 @@ package yang
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -261,6 +262,115 @@ func TestEntryNamespace(t *testing.T) {
 			t.Errorf("want namespace %s, got nil", tc.ns)
 		} else if tc.ns != nsValue.Name {
 			t.Errorf("want namespace %s, got %s", tc.ns, nsValue.Name)
+		}
+	}
+}
+
+func TestEntryDefaultValue(t *testing.T) {
+	getdir := func(e *Entry, elements ...string) (*Entry, error) {
+		for _, elem := range elements {
+			next := e.Dir[elem]
+			if next == nil {
+				return nil, fmt.Errorf("%s missing directory %q", e.Path(), elem)
+			}
+			e = next
+		}
+		return e, nil
+	}
+
+	modtext := `
+module defaults {
+  namespace "urn:defaults";
+  prefix "defaults";
+
+  typedef string-default {
+    type string;
+    default "typedef default string";
+  }
+
+  grouping common {
+    container common-nodefault {
+      leaf string {
+        type string;
+      }
+    }
+    container common-withdefault {
+      leaf string {
+        type string;
+        default "default string";
+      }
+    }
+    container common-typedef-withdefault {
+      leaf string {
+        type string-default;
+      }
+    }
+  }
+
+  container defaults {
+    leaf uint32-withdefault {
+      type uint32;
+      default 13;
+    }
+    leaf string-withdefault {
+      type string-default;
+    }
+    leaf nodefault {
+      type string;
+    }
+    uses common;
+  }
+
+}
+`
+
+	ms := NewModules()
+	if err := ms.Parse(modtext, "defaults.yang"); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range []struct {
+		want string
+		path []string
+	}{
+		{
+			path: []string{"defaults", "string-withdefault"},
+			want: "typedef default string",
+		},
+		{
+			path: []string{"defaults", "uint32-withdefault"},
+			want: "13",
+		},
+		{
+			path: []string{"defaults", "nodefault"},
+			want: "",
+		},
+		{
+			path: []string{"defaults", "common-withdefault", "string"},
+			want: "default string",
+		},
+		{
+			path: []string{"defaults", "common-typedef-withdefault", "string"},
+			want: "typedef default string",
+		},
+		{
+			path: []string{"defaults", "common-nodefault", "string"},
+			want: "",
+		},
+	} {
+		tname := strings.Join(tc.path, "/")
+
+		mod, err := ms.FindModuleByPrefix("defaults")
+		if err != nil {
+			t.Fatalf("[%d_%s] module not found: %v", i, tname, err)
+		}
+		defaults := ToEntry(mod)
+		dir, err := getdir(defaults, tc.path...)
+		if err != nil {
+			t.Fatalf("[%d_%s] could not retrieve path: %v", i, tname, err)
+		}
+		if got := dir.DefaultValue(); tc.want != got {
+			t.Errorf("[%d_%s] want DefaultValue %q, got %q", i, tname, tc.want, got)
 		}
 	}
 }


### PR DESCRIPTION
After ToEntry is called, if a "leaf" has an explicit "default" value
in the YANG schema, that leaf's Entry will have its Default field set
to the schema value.

 * Add a Default (string) field to the Entry struct.
 * During ToEntry, for Leaf nodes, copy the "default" value to the
   new Entry Default field.
 * Provide a function DefaultValue on *yang.Entry, which returns
   either the explicit leaf default, the Entry's type's default
   if it has one or the empty string otherwise.
 * Add unit test for the DefaultValue function covering leaf usage.