### PR TITLE
yang: Use portable path functions from filepath

### DIFF
--- a/pkg/yang/file.go
+++ b/pkg/yang/file.go
@@ -56,7 +56,7 @@ func PathsWithModules(root string) (paths []string, err error) {
 				return nil
 			}
 			if !info.IsDir() && strings.HasSuffix(p, ".yang") {
-				dir := path.Dir(p)
+				dir := filepath.Dir(p)
 				if !pm[dir] {
 					pm[dir] = true
 					paths = append(paths, dir)
@@ -92,7 +92,7 @@ func findFile(name string) (string, string, error) {
 
 	switch data, err := readFile(name); true {
 	case err == nil:
-		AddPath(path.Dir(name))
+		AddPath(filepath.Dir(name))
 		return name, string(data), nil
 	case slash >= 0:
 		// If there are any /'s in the name then don't search Path.
@@ -101,10 +101,10 @@ func findFile(name string) (string, string, error) {
 
 	for _, dir := range Path {
 		var n string
-		if path.Base(dir) == "..." {
-			n = findInDir(path.Dir(dir), name)
+		if filepath.Base(dir) == "..." {
+			n = findInDir(filepath.Dir(dir), name)
 		} else {
-			n = path.Join(dir, name)
+			n = filepath.Join(dir, name)
 		}
 		if n == "" {
 			continue

--- a/pkg/yang/file.go
+++ b/pkg/yang/file.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -125,11 +124,11 @@ func findInDir(dir, name string) string {
 	for _, fi := range fis {
 		if !fi.IsDir() {
 			if fi.Name() == name {
-				return path.Join(dir, name)
+				return filepath.Join(dir, name)
 			}
 			continue
 		}
-		if n := findInDir(path.Join(dir, fi.Name()), name); n != "" {
+		if n := findInDir(filepath.Join(dir, fi.Name()), name); n != "" {
 			return n
 		}
 	}

--- a/pkg/yang/file_test.go
+++ b/pkg/yang/file_test.go
@@ -17,6 +17,7 @@ package yang
 import (
 	"errors"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -29,6 +30,8 @@ func testPathReset() {
 func TestFindFile(t *testing.T) {
 	// clean up global state
 	defer testPathReset()
+
+	sep := string(os.PathSeparator)
 
 	for _, tt := range []struct {
 		name  string
@@ -50,7 +53,7 @@ func TestFindFile(t *testing.T) {
 		{
 			name:  "four",
 			path:  []string{"dir1", "dir2"},
-			check: []string{"four.yang", "dir1/four.yang", "dir2/four.yang"},
+			check: []string{"four.yang", "dir1" + sep + "four.yang", "dir2" + sep + "four.yang"},
 		},
 	} {
 		var checked []string


### PR DESCRIPTION
The "path" package's Base, Dir and Join functions use the Unix path
separator '/', which is not compatible with Windows. Use instead the
same named functions from the "path/filepth" package, which use the
system's path separator.

This change causes the test suite to pass on Windows 10 and should
similarly affect earlier versions of Windows.