### PR TITLE
yang: Allow file names with revision-dates

### DIFF
--- a/pkg/yang/file.go
+++ b/pkg/yang/file.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -71,11 +72,16 @@ func PathsWithModules(root string) (paths []string, err error) {
 // readFile makes testing of findFile easier.
 var readFile = ioutil.ReadFile
 
+// scanDir makes testing of findFile easier.
+var scanDir = findInDir
+
 // findFile returns the name and contents of the .yang file associated with
 // name, or an error.  If name is a module name rather than a file name (it does
 // not have a .yang extension and there is no / in name), .yang is appended to
 // the the name.  The directory that the .yang file is found in is added to Path
-// if not already in Path.
+// if not already in Path. If a file is not found by exact match, directories
+// are scanned for "name@revision-date.yang" files, the latest (sorted by
+// YYYY-MM-DD revision-date) of these will be selected.
 //
 // If a path has the form dir/... then dir and all direct or indirect
 // subdirectories of dir are searched.
@@ -84,9 +90,12 @@ var readFile = ioutil.ReadFile
 // Path.
 func findFile(name string) (string, string, error) {
 	slash := strings.Index(name, "/")
-
 	if slash < 0 && !strings.HasSuffix(name, ".yang") {
 		name += ".yang"
+		if best := scanDir(".", name, false); best != "" {
+			// we found a matching candidate in the local directory
+			name = best
+		}
 	}
 
 	switch data, err := readFile(name); true {
@@ -101,7 +110,7 @@ func findFile(name string) (string, string, error) {
 	for _, dir := range Path {
 		var n string
 		if filepath.Base(dir) == "..." {
-			n = findInDir(filepath.Dir(dir), name)
+			n = scanDir(filepath.Dir(dir), name, true)
 		} else {
 			n = filepath.Join(dir, name)
 		}
@@ -115,22 +124,43 @@ func findFile(name string) (string, string, error) {
 	return "", "", fmt.Errorf("no such file: %s", name)
 }
 
-// findInDir looks for a file named name in dir or any of its subdirectories.
-func findInDir(dir, name string) string {
+// findInDir looks for a file named name in dir or any of its subdirectories if
+// recurse is true. if recurse is false, scan only the directory dir.
+func findInDir(dir, name string, recurse bool) string {
 	fis, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return ""
 	}
+	var candidates []string
+	mname := name
+	if strings.HasSuffix(mname, ".yang") {
+		mname = name[:len(name)-len(".yang")]
+	}
+
 	for _, fi := range fis {
 		if !fi.IsDir() {
 			if fi.Name() == name {
 				return filepath.Join(dir, name)
+			} else if !strings.Contains(name, "@") && strings.HasPrefix(fi.Name(), mname+"@") && strings.HasSuffix(fi.Name(), ".yang") {
+				candidates = append(candidates, fi.Name())
 			}
 			continue
 		}
-		if n := findInDir(filepath.Join(dir, fi.Name()), name); n != "" {
-			return n
+		if recurse {
+			if n := findInDir(filepath.Join(dir, fi.Name()), name, recurse); n != "" {
+				return n
+			}
 		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	// sort the candidates and return the ultimate ("highest") value, which in
+	// the case of revision-date fields per the module file name format (RFC6020
+	// section 5.2) should be the newest candidate.
+	sort.Strings(candidates)
+	if best := candidates[len(candidates)-1]; best != "" {
+		return filepath.Join(dir, best)
 	}
 	return ""
 }

--- a/pkg/yang/file_test.go
+++ b/pkg/yang/file_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -61,6 +62,9 @@ func TestFindFile(t *testing.T) {
 		readFile = func(path string) ([]byte, error) {
 			checked = append(checked, path)
 			return nil, errors.New("no such file")
+		}
+		scanDir = func(dir, name string, recurse bool) string {
+			return filepath.Join(dir, name)
 		}
 		if _, _, err := findFile(tt.name); err == nil {
 			t.Errorf("%s unexpectedly succeeded", tt.name)

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -390,7 +390,6 @@ func (ms *Modules) include(m *Module) error {
 	for _, i := range m.Include {
 		im := ms.FindModule(i)
 		if im == nil {
-			// TODO(borman): should print @rev if available
 			return fmt.Errorf("no such submodule: %s", i.Name)
 		}
 		// Process the include statements in our included module.
@@ -405,7 +404,6 @@ func (ms *Modules) include(m *Module) error {
 	for _, i := range m.Import {
 		im := ms.FindModule(i)
 		if im == nil {
-			// TODO(borman): should print @rev if available
 			return fmt.Errorf("no such module: %s", i.Name)
 		}
 		// Process the include statements in our included module.


### PR DESCRIPTION
This change permits scanning YANG paths for YANG module files matching
the specification in section 5.2 of RFC6020. These include module names
with revision-date fields, such as an example module "foo", with a
revision date of 2016-12-31:

  foo@2016-12-31.yang

A module that makes an import for "foo" without specifying an
revision-date argument in its import statement (i.e., the regular state
of YANG modules found in the wild) will, before this change, fail to
find a module file (it would look for "foo.yang" in relevant paths).

After this change, goyang can successfully import the IETF RFC modules
directory (e.g,. importing ietf-system will successfully import the
latest versions of the ietf-types and ietf-netconf-acm modules).