### PR TITLE
Resolve Type statements in deviations during module processing

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -570,10 +570,19 @@ func ToEntry(n Node) (e *Entry) {
 		case "default",
 			"typedef":
 			continue
+		case "deviation":
+			if a := fv.Interface().([]*Deviation); a != nil {
+				for _, d := range a {
+					for _, sd := range d.Deviate {
+						if sd.Type != nil {
+							sd.Type.resolve()
+						}
+					}
+				}
+			}
 		// TODO(borman): unimplemented keywords
 		case "belongs-to",
 			"contact",
-			"deviation",
 			"extension",
 			"feature",
 			"if-feature",


### PR DESCRIPTION
The Type statments in deviations need to be resolved in the processing
phase. This is done in ToEntry for 'Type's in the modules. However,
it is not done anywhere for Type in deviations.

When implementations try to apply deviations, they find that the Type
is unresolved.

Alternative to this fix, would be to make the function "resolve" on the
"Type" public so implementations can use it for resolution when they
apply the deviations.