### PR TITLE
Add Support for Ignoring Circular Dependencies

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,4 +10,5 @@
 #     Name <email address>
 
 Paul Borman <borman@google.com>
+Andrew Fort <afort@arista.com>
 Rob Shakir <robjs@google.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@
 #     Name <email address>
 
 Paul Borman <borman@google.com>
+Rob Shakir <robjs@google.com>

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -509,12 +509,12 @@ func ToEntry(n Node) (e *Entry) {
 				// us to ensure that we do not process circular dependencies that exist
 				// in some module's include chains.
 				switch {
-				case a.Module.NName() == n.NName() && !ParseOptions.IgnoreSubmoduleCircularDependencies:
-					e.addError(fmt.Errorf("%s: has a circular dependency", n.NName()))
-				case a.Module.NName() == n.NName():
+				case a.Module.NName() != n.NName():
+					e.merge(a.Module.Prefix, ToEntry(a.Module))
+				case ParseOptions.IgnoreSubmoduleCircularDependencies:
 					continue
 				default:
-					e.merge(a.Module.Prefix, ToEntry(a.Module))
+					e.addError(fmt.Errorf("%s: has a circular dependency", n.NName()))
 				}
 			}
 		case "leaf":

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -500,7 +500,18 @@ func ToEntry(n Node) (e *Entry) {
 			// available.  There is nothing else for us to do.
 		case "include":
 			for _, a := range fv.Interface().([]*Include) {
-				e.merge(a.Module.Prefix, ToEntry(a.Module))
+				// Specifically handle the case that the submodule's name is the same
+				// as the node that we are currently converting to an entry. This allows
+				// us to ensure that we do not process circular dependencies that exist
+				// in some module's include chains.
+				switch {
+				case a.Module.NName() == n.NName() && !ParseOptions.IgnoreSubmoduleCircularDependencies:
+					e.addError(fmt.Errorf("%s: has a circular dependency", n.NName()))
+				case a.Module.NName() == n.NName():
+					continue
+				default:
+					e.merge(a.Module.Prefix, ToEntry(a.Module))
+				}
 			}
 		case "leaf":
 			for _, a := range fv.Interface().([]*Leaf) {

--- a/pkg/yang/options.go
+++ b/pkg/yang/options.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yang
+
+// Options defines the options that should be used when parsing YANG modules,
+// including specific overrides for potentially problematic YANG constructs.
+type Options struct {
+	// IgnoreSubmoduleCircularDependencies specifies whether circular dependencies
+	// between submodules. Setting this value to true will ensure that this
+	// package will explicitly ignore the case where a submodule will include
+	// itself through a circular reference.
+	IgnoreSubmoduleCircularDependencies bool
+}
+
+var ParseOptions = Options{}

--- a/yang.go
+++ b/yang.go
@@ -95,6 +95,7 @@ func main() {
 	getopt.StringVarLong(&format, "format", 0, "format to display: "+strings.Join(formats, ", "), "FORMAT")
 	getopt.StringVarLong(&traceP, "trace", 0, "write trace into to TRACEFILE", "TRACEFILE")
 	getopt.BoolVarLong(&help, "help", '?', "display help")
+	getopt.BoolVarLong(&yang.ParseOptions.IgnoreSubmoduleCircularDependencies, "ignore-circdep", 0, "ignore circular dependencies between submodules")
 	getopt.SetParameters("[FORMAT OPTIONS] [SOURCE] [...]")
 
 	if err := getopt.Getopt(func(o getopt.Option) bool {


### PR DESCRIPTION
Per #35, this PR requests to add functionality to allow circular dependencies in submodules to be ignored, the default behaviour in this case is also modified to ensure that goyang doesn't enter an infinite loop in this case, and rather returns an error.

In order to control whether an error should be thrown, a `ParseOptions` struct is created which allows particular options (such as the one to ignore circular dependencies) to be set by the calling package. A command-line flag is also added to the `goyang` binary to allow this to be specified. 