### PR TITLE
Fix bug with identity equality; fix identity tests.

### DIFF
--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -320,6 +320,7 @@ func (y *YangType) Equal(t *YangType) bool {
 		y.Units != t.Units,
 		y.Default != t.Default,
 		y.FractionDigits != t.FractionDigits,
+		y.IdentityBase != t.IdentityBase,
 		len(y.Length) != len(t.Length),
 		!y.Length.Equal(t.Length),
 		y.OptionalInstance != t.OptionalInstance,


### PR DESCRIPTION
In `openconfig-platform`, this leaf exists:

```
    leaf type {
      type union {
        type identityref {
          base oc-platform-types:OPENCONFIG_HARDWARE_COMPONENT;
        }
        type identityref {
          base oc-platform-types:OPENCONFIG_SOFTWARE_COMPONENT;
        }
      }
      description
        "Type of component as identified by the system";
    }
```

This union would be reported as having a single member as the two `identityref` types were considered equal. This commit fixes this issue.

```
 * (M) pkg/yang/identity_test.go
   - Ensure that identityref leaves were actually checked by unit
     test.
   - Add a test case with a union that includes two identityrefs,
     which would previously fail due to the fact that identities
     were considered equal even if they had differing bases.
 * (M) pkg/yang/types_builtin.go
   - Fix equality of identities to consider the base statement,
     this would previously cause unions that contained identityrefs
     to only include the first identityref, even if the bases
     differed.
```