### PR TITLE
Add handling for circular dependencies which are not direct submodules.

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -309,6 +309,11 @@ func (e *Entry) add(key string, value *Entry) *Entry {
 // converted nodes.
 var entryCache = map[Node]*Entry{}
 
+// mergedSubmodule is used to prevent re-parsing a submodule that has already
+// been merged into a particular entity when circular dependencies are being
+// ignored.
+var mergedSubmodule = map[string]map[string]bool{}
+
 var depth = 0
 
 // ToEntry expands node n into a directory Entry.  Expansion is based on the
@@ -406,7 +411,7 @@ func ToEntry(n Node) (e *Entry) {
 		}
 		return e
 	case *Uses:
-		g := FindGrouping(s, s.Name)
+		g := FindGrouping(s, s.Name, map[string]bool{})
 		if g == nil {
 			return newError(n, "unknown group: %s", s.Name)
 		}
@@ -504,17 +509,27 @@ func ToEntry(n Node) (e *Entry) {
 			// available.  There is nothing else for us to do.
 		case "include":
 			for _, a := range fv.Interface().([]*Include) {
-				// Specifically handle the case that the submodule's name is the same
-				// as the node that we are currently converting to an entry. This allows
-				// us to ensure that we do not process circular dependencies that exist
-				// in some module's include chains.
+				// Handle circular dependencies between submodules. This can occur in
+				// two ways:
+				//  - Where submodule A imports submodule B, and vice versa then the
+				//    whilst processing A we will also try and process A (learnt via
+				//    B). The default case of the switch handles this case.
+				//  - Where submodule A imports submodule B that imports C, which also
+				//    imports A, then we need to check whether we already have merged
+				//    the specified module during this parse attempt. We check this
+				//    against a map of merged submodules.
+				_, merged := mergedSubmodule[a.Module.NName()][n.NName()]
 				switch {
-				case a.Module.NName() != n.NName():
+				case !merged && a.Module.NName() != n.NName():
+					if _, ok := mergedSubmodule[a.Module.NName()]; !ok {
+						mergedSubmodule[a.Module.NName()] = map[string]bool{}
+					}
+					mergedSubmodule[a.Module.NName()][n.NName()] = true
 					e.merge(a.Module.Prefix, ToEntry(a.Module))
 				case ParseOptions.IgnoreSubmoduleCircularDependencies:
 					continue
 				default:
-					e.addError(fmt.Errorf("%s: has a circular dependency", n.NName()))
+					e.addError(fmt.Errorf("%s: has a circular dependency, importing %s", a.Module.Name, n.NName()))
 				}
 			}
 		case "leaf":

--- a/pkg/yang/find.go
+++ b/pkg/yang/find.go
@@ -44,9 +44,10 @@ func trimPrefix(n Node, name string) string {
 }
 
 // FindGrouping finds the grouping named name in one of the parent node's
-// grouping fields.  If no parent has the named grouping, nil is returned.
-// Imported and included modules are also checked.
-func FindGrouping(n Node, name string, checkedInclude map[string]bool) *Grouping {
+// grouping fields, seen provides a list of the modules previously seen
+// by FindGrouping during traversal.  If no parent has the named grouping, 
+// nil is returned. Imported and included modules are also checked.
+func FindGrouping(n Node, name string, seen map[string]bool) *Grouping {
 	name = trimPrefix(n, name)
 	for n != nil {
 		// Grab the Grouping field of the underlying structure.  n is
@@ -74,7 +75,7 @@ func FindGrouping(n Node, name string, checkedInclude map[string]bool) *Grouping
 				if pname == name {
 					continue
 				}
-				if g := FindGrouping(i.Module, pname, checkedInclude); g != nil {
+				if g := FindGrouping(i.Module, pname, seen); g != nil {
 					return g
 				}
 			}
@@ -82,7 +83,7 @@ func FindGrouping(n Node, name string, checkedInclude map[string]bool) *Grouping
 		v = e.FieldByName("Include")
 		if v.IsValid() {
 			for _, i := range v.Interface().([]*Include) {
-				if _, c := checkedInclude[i.Module.Name]; c {
+				if seen[i.Module.Name] {
 					switch ParseOptions.IgnoreSubmoduleCircularDependencies {
 					case true:
 						continue
@@ -94,8 +95,8 @@ func FindGrouping(n Node, name string, checkedInclude map[string]bool) *Grouping
 						return nil
 					}
 				}
-				checkedInclude[i.Module.Name] = true
-				if g := FindGrouping(i.Module, name, checkedInclude); g != nil {
+				seen[i.Module.Name] = true
+				if g := FindGrouping(i.Module, name, seen); g != nil {
 					return g
 				}
 			}

--- a/pkg/yang/find.go
+++ b/pkg/yang/find.go
@@ -46,7 +46,7 @@ func trimPrefix(n Node, name string) string {
 // FindGrouping finds the grouping named name in one of the parent node's
 // grouping fields.  If no parent has the named grouping, nil is returned.
 // Imported and included modules are also checked.
-func FindGrouping(n Node, name string) *Grouping {
+func FindGrouping(n Node, name string, checkedInclude map[string]bool) *Grouping {
 	name = trimPrefix(n, name)
 	for n != nil {
 		// Grab the Grouping field of the underlying structure.  n is
@@ -74,7 +74,7 @@ func FindGrouping(n Node, name string) *Grouping {
 				if pname == name {
 					continue
 				}
-				if g := FindGrouping(i.Module, pname); g != nil {
+				if g := FindGrouping(i.Module, pname, checkedInclude); g != nil {
 					return g
 				}
 			}
@@ -82,7 +82,20 @@ func FindGrouping(n Node, name string) *Grouping {
 		v = e.FieldByName("Include")
 		if v.IsValid() {
 			for _, i := range v.Interface().([]*Include) {
-				if g := FindGrouping(i.Module, name); g != nil {
+				if _, c := checkedInclude[i.Module.Name]; c {
+					switch ParseOptions.IgnoreSubmoduleCircularDependencies {
+					case true:
+						continue
+					default:
+						// We have an undetected circular dependency that has occurred.
+						// This should not be possible to hit, since ToEntry should have
+						// converted the entries successfully, however, we return nil to
+						// avoid infinitely looping and causing a panic.
+						return nil
+					}
+				}
+				checkedInclude[i.Module.Name] = true
+				if g := FindGrouping(i.Module, name, checkedInclude); g != nil {
 					return g
 				}
 			}


### PR DESCRIPTION
Hi Paul,

This adds some further handling for circular dependencies that is seen in a set of modules that we're wanting to code generation for. PTAL!

Thanks again for the reviews :-)

Cheers,
r.

``` 
  * (M) pkg/yang/entry.go
    - Add handling for circular dependencies that are not simply direct
      submodule inclusions, such as those seen in some vendor YANG modules.
      This implementation uses a map of entity (submodule, or module) to
      included submodule such that grandchildren of a module include a
      submodule that was already included can be detected.
  * (M) pkg/yang/entry_test.go
    - Add testing for particular cases observed in vendor modules.
  * (M) pkg/yang/find.go
    - Ensure that FindGrouping cannot enter an infinite loop when
      circular dependencies exist - either exiting gracefully, or
      skipping already inspected submodules.
```