### PR TITLE
Fix golint/govet issues,

### DIFF
--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -209,7 +209,7 @@ func (ms *Modules) FindModuleByNamespace(ns string) (*Module, error) {
 			switch {
 			case m == found:
 			case found != nil:
-				return nil, fmt.Errorf("namespace %s matches two or more modules (%s, %s)\n",
+				return nil, fmt.Errorf("namespace %s matches two or more modules (%s, %s)",
 					ns, found.Name, m.Name)
 			default:
 				found = m

--- a/pkg/yang/modules_test.go
+++ b/pkg/yang/modules_test.go
@@ -40,7 +40,7 @@ func testModulesForTestdataModulesText(t *testing.T) *yang.Modules {
 	}
 	if errs := ms.Process(); errs != nil {
 		for _, err := range errs {
-			t.Errorf("error %d: %v", err)
+			t.Errorf("error: %v", err)
 		}
 		t.Fatalf("fatal error(s) calling Process()")
 	}

--- a/pkg/yang/options.go
+++ b/pkg/yang/options.go
@@ -24,4 +24,7 @@ type Options struct {
 	IgnoreSubmoduleCircularDependencies bool
 }
 
+// ParseOptions sets the options for the current YANG module parsing. It can be
+// directly set by the caller to influence how goyang will behave in the presence
+// of certain exceptional cases.
 var ParseOptions = Options{}


### PR DESCRIPTION
Clean up a number of govet/golint errors in pkg/yang.

```
  * (M) pkg/yang/modules.go
    - Remove newline terminating error string.
  * (M) pkg/yang/modules_test.go
    - Remove count for errors in test output which did not get
      populated.
  * (M) pkg/yang/options.go
    - Add comment for global ParseOptions struct.
```