### PR TITLE
Handle esoteric include cases, and stale state

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -531,15 +531,16 @@ func ToEntry(n Node) (e *Entry) {
 				case !merged && a.Module.NName() != n.NName():
 					parentkey := a.Module.Name + ":" + a.Module.BelongsTo.Name
 					if mergedSubmodule[parentkey] {
-						// Don't try and re-import submodules that our parent actually
-						// imported. This avoids duplication in the case that we have:
-						//      Parent
-						//        / \
-						//       v  v
-						//      Son->Daughter
+						// Don't try and re-import submodules that have already been imported
+						// into the top-level module. Note that this ensures that we get to the
+						// top the tree (whichever the actual module for the chain of
+						// submodules is). The tracking of the immediate parent is achieved
+						// through 'key', which ensures that we do not end up in loops
+						// walking through a sub-cycle of the include graph.
 						continue
 					}
 					mergedSubmodule[key] = true
+					mergedSubmodule[parentkey] = true
 					e.merge(a.Module.Prefix, ToEntry(a.Module))
 				case ParseOptions.IgnoreSubmoduleCircularDependencies:
 					continue

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -17,6 +17,8 @@ package yang
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -486,6 +488,8 @@ func TestFullModuleProcess(t *testing.T) {
 		name             string
 		inModules        map[string]string
 		inIgnoreCircDeps bool
+		wantLeaves       map[string][]string
+		wantErr          bool
 	}{{
 		name: "circular import via child",
 		inModules: map[string]string{
@@ -532,10 +536,100 @@ func TestFullModuleProcess(t *testing.T) {
       }`,
 		},
 		inIgnoreCircDeps: true,
+	}, {
+		name: "non-circular via child",
+		inModules: map[string]string{
+			"bgp": `
+			module bgp {
+			  prefix "bgp";
+			  namespace "urn:bgp";
+
+			  include bgp-son;
+			  include bgp-daughter;
+
+			  leaf parent { type string; }
+			}`,
+			"bgp-son": `
+			submodule bgp-son {
+			  belongs-to bgp { prefix "bgp"; }
+
+			  leaf son { type string; }
+			}`,
+			"bgp-daughter": `
+			submodule bgp-daughter {
+			  belongs-to bgp { prefix "bgp"; }
+			  include bgp-son;
+
+			  leaf daughter { type string; }
+			}`,
+		},
+	}, {
+		name: "simple circular via child",
+		inModules: map[string]string{
+			"parent": `
+			module parent {
+			  prefix "p";
+			  namespace "urn:p";
+				include son;
+				include daughter;
+
+			  leaf p { type string; }
+			}
+			`,
+			"son": `
+			submodule son {
+			  belongs-to parent { prefix "p"; }
+			  include daughter;
+
+			  leaf s { type string; }
+			}
+			`,
+			"daughter": `
+			submodule daughter {
+			  belongs-to parent { prefix "p"; }
+			  include son;
+
+			  leaf d { type string; }
+			}
+			`,
+		},
+		wantErr: true,
+	}, {
+		name: "merge via grandchild",
+		inModules: map[string]string{
+			"bgp": `
+				module bgp {
+				  prefix "bgp";
+				  namespace "urn:bgp";
+
+				  include bgp-son;
+
+				  leaf parent { type string; }
+				}`,
+			"bgp-son": `
+				submodule bgp-son {
+				  belongs-to bgp { prefix "bgp"; }
+
+					include bgp-grandson;
+
+				  leaf son { type string; }
+				}`,
+			"bgp-grandson": `
+				submodule bgp-grandson {
+				  belongs-to bgp { prefix "bgp"; }
+
+				  leaf grandson { type string; }
+				}`,
+		},
+		wantLeaves: map[string][]string{
+			"bgp": []string{"parent", "son", "grandson"},
+		},
 	}}
 
 	for _, tt := range tests {
 		ms := NewModules()
+        mergedSubmodule = map[string]bool{}
+
 		ParseOptions.IgnoreSubmoduleCircularDependencies = tt.inIgnoreCircDeps
 		for n, m := range tt.inModules {
 			if err := ms.Parse(m, n); err != nil {
@@ -544,7 +638,35 @@ func TestFullModuleProcess(t *testing.T) {
 		}
 
 		if errs := ms.Process(); len(errs) > 0 {
-			t.Errorf("%s: error processing modules, got: %v, want: nil", tt.name, errs)
+			if !tt.wantErr {
+				t.Errorf("%s: error processing modules, got: %v, want: nil", tt.name, errs)
+			}
+			continue
+		}
+
+		if tt.wantErr {
+			t.Errorf("%s: did not get expected errors", tt.name)
+			continue
+		}
+
+		for m, l := range tt.wantLeaves {
+			mod, errs := ms.GetModule(m)
+			if len(errs) > 0 {
+				t.Errorf("%s: cannot retrieve expected module %s, got: %v, want: nil", tt.name, m, errs)
+				continue
+			}
+
+			var leaves []string
+			for _, n := range mod.Dir {
+				leaves = append(leaves, n.Name)
+			}
+
+			// Sort the two slices to ensure that we are comparing like with like.
+			sort.Strings(l)
+			sort.Strings(leaves)
+			if !reflect.DeepEqual(l, leaves) {
+				t.Errorf("%s: did not get expected leaves in %s, got: %v, want: %v", tt.name, m, leaves, l)
+			}
 		}
 	}
 }

--- a/pkg/yang/find.go
+++ b/pkg/yang/find.go
@@ -45,7 +45,7 @@ func trimPrefix(n Node, name string) string {
 
 // FindGrouping finds the grouping named name in one of the parent node's
 // grouping fields, seen provides a list of the modules previously seen
-// by FindGrouping during traversal.  If no parent has the named grouping, 
+// by FindGrouping during traversal.  If no parent has the named grouping,
 // nil is returned. Imported and included modules are also checked.
 func FindGrouping(n Node, name string, seen map[string]bool) *Grouping {
 	name = trimPrefix(n, name)
@@ -84,16 +84,10 @@ func FindGrouping(n Node, name string, seen map[string]bool) *Grouping {
 		if v.IsValid() {
 			for _, i := range v.Interface().([]*Include) {
 				if seen[i.Module.Name] {
-					switch ParseOptions.IgnoreSubmoduleCircularDependencies {
-					case true:
-						continue
-					default:
-						// We have an undetected circular dependency that has occurred.
-						// This should not be possible to hit, since ToEntry should have
-						// converted the entries successfully, however, we return nil to
-						// avoid infinitely looping and causing a panic.
-						return nil
-					}
+					// Prevent infinite loops in the case that we have already looked at
+					// this submodule. This occurs where submodules have include statements
+					// in them, or there is a circular dependency.
+					continue
 				}
 				seen[i.Module.Name] = true
 				if g := FindGrouping(i.Module, name, seen); g != nil {

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -315,10 +315,10 @@ func (ms *Modules) process() []error {
 // not mean these are all the errors.  Process will terminate processing early
 // based on the type and location of the error.
 func (ms *Modules) Process() []error {
-    // Reset globals that may remain stale if multiple Process() calls are
-    // made by the same caller.
-    mergedSubmodule = map[string]bool{}
-    entryCache = map[Node]*Entry{}
+	// Reset globals that may remain stale if multiple Process() calls are
+	// made by the same caller.
+	mergedSubmodule = map[string]bool{}
+	entryCache = map[Node]*Entry{}
 
 	errs := ms.process()
 	if len(errs) > 0 {

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -315,6 +315,11 @@ func (ms *Modules) process() []error {
 // not mean these are all the errors.  Process will terminate processing early
 // based on the type and location of the error.
 func (ms *Modules) Process() []error {
+    // Reset globals that may remain stale if multiple Process() calls are
+    // made by the same caller.
+    mergedSubmodules = map[string]bool{}
+    entryCache = map[Node]*Entry{}
+
 	errs := ms.process()
 	if len(errs) > 0 {
 		return errorSort(errs)

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -317,7 +317,7 @@ func (ms *Modules) process() []error {
 func (ms *Modules) Process() []error {
     // Reset globals that may remain stale if multiple Process() calls are
     // made by the same caller.
-    mergedSubmodules = map[string]bool{}
+    mergedSubmodule = map[string]bool{}
     entryCache = map[Node]*Entry{}
 
 	errs := ms.process()


### PR DESCRIPTION
This PR handles a more esoteric case of submodule chains being used, and ensures that if a caller makes subsequent calls to `Process()` then some of the global state that `ToEntry(...)` creates is cleaned up. 

In the future, it'd be preferable to move ToEntry to have a context of the `Modules` that it is working on, but this needs wider changes. Currently, `mergedSubmodule` being stale causes tests on code generation to fail internally.