### PR TITLE
Add support for marshaling yang.Entry to JSON.

### DIFF
--- a/pkg/yang/ast.go
+++ b/pkg/yang/ast.go
@@ -98,18 +98,18 @@ func build(s *Statement, p reflect.Value) (v reflect.Value, err error) {
 			addTypedefs(t)
 		}
 	}()
-	kind := s.keyword
-	if k := aliases[s.keyword]; k != "" {
+	kind := s.Keyword
+	if k := aliases[s.Keyword]; k != "" {
 		kind = k
 	}
 	t := nameMap[kind]
 	if t == nil {
 		// It is not an error if this is an extension.
 		// TODO(borman): what do we do with them?
-		if strings.Index(s.keyword, ":") > 0 {
+		if strings.Index(s.Keyword, ":") > 0 {
 			return nilValue, nil
 		}
-		return nilValue, fmt.Errorf("%s: unknown statement: %s", s.Location(), s.keyword)
+		return nilValue, fmt.Errorf("%s: unknown statement: %s", s.Location(), s.Keyword)
 	}
 	y := typeMap[t]
 	found := map[string]bool{}
@@ -147,9 +147,9 @@ func build(s *Statement, p reflect.Value) (v reflect.Value, err error) {
 	// Now handle the substatements
 
 	for _, ss := range s.statements {
-		found[ss.keyword] = true
-		fn := y.funcs[ss.keyword]
-		parts := strings.Split(ss.keyword, ":")
+		found[ss.Keyword] = true
+		fn := y.funcs[ss.Keyword]
+		parts := strings.Split(ss.Keyword, ":")
 		switch {
 		case fn != nil:
 			// Normal case, the keyword is known.
@@ -164,32 +164,32 @@ func build(s *Statement, p reflect.Value) (v reflect.Value, err error) {
 			}
 			y.addext(ss, v, p)
 		default:
-			return nilValue, fmt.Errorf("%s: unknown %s field: %s", ss.Location(), s.keyword, ss.keyword)
+			return nilValue, fmt.Errorf("%s: unknown %s field: %s", ss.Location(), s.Keyword, ss.Keyword)
 		}
 	}
 
 	// Make sure all of our required field are there.
 	for _, r := range y.required {
 		if !found[r] {
-			return nilValue, fmt.Errorf("%s: missing required %s field: %s", s.Location(), s.keyword, r)
+			return nilValue, fmt.Errorf("%s: missing required %s field: %s", s.Location(), s.Keyword, r)
 		}
 	}
 
 	// Make sure required fields based on our keyword are there (module vs submodule)
-	for _, r := range y.sRequired[s.keyword] {
+	for _, r := range y.sRequired[s.Keyword] {
 		if !found[r] {
-			return nilValue, fmt.Errorf("%s: missing required %s field: %s", s.Location(), s.keyword, r)
+			return nilValue, fmt.Errorf("%s: missing required %s field: %s", s.Location(), s.Keyword, r)
 		}
 	}
 
 	// Make sure we don't have any field set that is required by a different keyword.
 	for n, or := range y.sRequired {
-		if n == s.keyword {
+		if n == s.Keyword {
 			continue
 		}
 		for _, r := range or {
 			if found[r] {
-				return nilValue, fmt.Errorf("%s: unknown %s field: %s", s.Location(), s.keyword, r)
+				return nilValue, fmt.Errorf("%s: unknown %s field: %s", s.Location(), s.Keyword, r)
 			}
 		}
 	}
@@ -358,10 +358,10 @@ func initTypes(at reflect.Type) {
 				}
 				fv := v.Elem().Field(i)
 				if fv.String() != "" {
-					return errors.New(s.keyword + ": already set")
+					return errors.New(s.Keyword + ": already set")
 				}
 
-				v.Elem().Field(i).SetString(s.argument)
+				v.Elem().Field(i).SetString(s.Argument)
 				return nil
 			}
 
@@ -391,7 +391,7 @@ func initTypes(at reflect.Type) {
 				}
 				fv := v.Elem().Field(i)
 				if !fv.IsNil() {
-					return errors.New(s.keyword + ": already set")
+					return errors.New(s.Keyword + ": already set")
 				}
 
 				// Use build to build the value for this field.

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -66,37 +66,37 @@ func (t TriState) String() string {
 // AST.  Directory entries have a non-nil Dir entry.  Leaf nodes have a nil
 // Dir entry.  If Errors is not nil then the only other valid field is Node.
 type Entry struct {
-	Parent      *Entry
-	Node        Node      // the base node this Entry was derived from.
+	Parent      *Entry    `json:"-"`
+	Node        Node      `json:"-"` // the base node this Entry was derived from.
 	Name        string    // our name, same as the key in our parent Dirs
-	Description string    // description from node, if any
-	Default     string    // default from node, if any
-	Errors      []error   // list of errors encounterd on this node
+	Description string    `json:",omitempty"` // description from node, if any
+	Default     string    `json:",omitempty"` // default from node, if any
+	Errors      []error   `json:"-"`          // list of errors encounterd on this node
 	Kind        EntryKind // kind of Entry
 	Config      TriState  // config state of this entry, if known
-	Prefix      *Value    // prefix to use from this point down
+	Prefix      *Value    `json:",omitempty"` // prefix to use from this point down
 
 	// Fields associated with directory nodes
-	Dir map[string]*Entry
-	Key string // Optional key name for lists (i.e., maps)
+	Dir map[string]*Entry `json:",omitempty"`
+	Key string            `json:",omitempty"` // Optional key name for lists (i.e., maps)
 
 	// Fields associated with leaf nodes
-	Type *YangType
-	Exts []*Statement // extensions found
+	Type *YangType    `json:",omitempty"`
+	Exts []*Statement `json:",omitempty"` // extensions found
 
 	// Fields associated with list nodes (both lists and leaf-lists)
-	ListAttr *ListAttr
+	ListAttr *ListAttr `json:",omitempty"`
 
-	RPC *RPCEntry // set if we are an RPC
+	RPC *RPCEntry `json:",omitempty"` // set if we are an RPC
 
 	// Identities that are defined in this context, this is set if the Entry
 	// is a module only.
-	Identities []*Identity
+	Identities []*Identity `json:",omitempty"`
 
-	Augments []*Entry // Augments associated with this entry
+	Augments []*Entry `json:"-"` // Augments associated with this entry
 
 	// Extra maps all the unsupported fields to their values
-	Extra map[string][]interface{}
+	Extra map[string][]interface{} `json:"-"`
 }
 
 // An RPCEntry contains information related to an RPC Node.

--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -1,0 +1,575 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yang
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      *Entry
+		want    string
+		wantErr bool
+	}{{
+		name: "simple leaf entry",
+		in: &Entry{
+			Name: "leaf",
+			Node: &Leaf{
+				Name: "leaf",
+			},
+			Description: "This is a fake leaf.",
+			Default:     "default-leaf-value",
+			Errors:      []error{fmt.Errorf("error one")},
+			Kind:        LeafEntry,
+			Config:      TSTrue,
+			Prefix: &Value{
+				Name: "ModulePrefix",
+				Source: &Statement{
+					Keyword:  "prefix",
+					Argument: "ModulePrefix",
+				},
+			},
+			Type: &YangType{
+				Name:    "string",
+				Kind:    Ystring,
+				Default: "string-value",
+			},
+		},
+		want: `{
+  "Name": "leaf",
+  "Description": "This is a fake leaf.",
+  "Default": "default-leaf-value",
+  "Kind": 0,
+  "Config": 1,
+  "Prefix": {
+    "Name": "ModulePrefix",
+    "Source": {
+      "Keyword": "prefix",
+      "Argument": "ModulePrefix"
+    }
+  },
+  "Type": {
+    "Name": "string",
+    "Kind": 18,
+    "Default": "string-value"
+  }
+}`,
+	}, {
+		name: "simple container entry with parent",
+		in: &Entry{
+			Name: "container",
+			Node: &Container{
+				Name: "container",
+			},
+			Kind:   DirectoryEntry,
+			Config: TSFalse,
+			Prefix: &Value{
+				Name: "ModulePrefix",
+				Source: &Statement{
+					Keyword:  "prefix",
+					Argument: "ModulePrefix",
+				},
+			},
+			Dir: map[string]*Entry{
+				"child": {
+					Name: "leaf",
+					Node: &Leaf{
+						Name: "leaf",
+					},
+					Kind:   LeafEntry,
+					Config: TSUnset,
+					Prefix: &Value{
+						Name: "ModulePrefix",
+						Source: &Statement{
+							Keyword:  "prefix",
+							Argument: "ModulePrefix",
+						},
+					},
+					Type: &YangType{
+						Name: "union",
+						Type: []*YangType{{
+							Name:    "string",
+							Pattern: []string{"^a.*$"},
+							Kind:    Ystring,
+							Length: YangRange{{
+								Min: FromInt(10),
+								Max: FromInt(20),
+							}},
+						}},
+					},
+				},
+			},
+		},
+		want: `{
+  "Name": "container",
+  "Kind": 1,
+  "Config": 2,
+  "Prefix": {
+    "Name": "ModulePrefix",
+    "Source": {
+      "Keyword": "prefix",
+      "Argument": "ModulePrefix"
+    }
+  },
+  "Dir": {
+    "child": {
+      "Name": "leaf",
+      "Kind": 0,
+      "Config": 0,
+      "Prefix": {
+        "Name": "ModulePrefix",
+        "Source": {
+          "Keyword": "prefix",
+          "Argument": "ModulePrefix"
+        }
+      },
+      "Type": {
+        "Name": "union",
+        "Kind": 0,
+        "Type": [
+          {
+            "Name": "string",
+            "Kind": 18,
+            "Length": [
+              {
+                "Min": {
+                  "Kind": 0,
+                  "Value": 10
+                },
+                "Max": {
+                  "Kind": 0,
+                  "Value": 20
+                }
+              }
+            ],
+            "Pattern": [
+              "^a.*$"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}`,
+	}, {
+		name: "Entry with list and leaflist",
+		in: &Entry{
+			Name:   "list",
+			Kind:   DirectoryEntry,
+			Config: TSUnset,
+			Dir: map[string]*Entry{
+				"leaf": {
+					Name: "string",
+					Kind: LeafEntry,
+				},
+				"leaf-list": {
+					Name:     "leaf-list",
+					ListAttr: &ListAttr{},
+				},
+			},
+			ListAttr: &ListAttr{
+				MaxElements: &Value{
+					Name: "42",
+				},
+				MinElements: &Value{
+					Name: "48",
+				},
+			},
+			Identities: []*Identity{{
+				Name: "ID_ONE",
+			}},
+			Exts: []*Statement{{
+				Keyword:  "some-extension:ext",
+				Argument: "ext-value",
+			}},
+		},
+		want: `{
+  "Name": "list",
+  "Kind": 1,
+  "Config": 0,
+  "Dir": {
+    "leaf": {
+      "Name": "string",
+      "Kind": 0,
+      "Config": 0
+    },
+    "leaf-list": {
+      "Name": "leaf-list",
+      "Kind": 0,
+      "Config": 0,
+      "ListAttr": {
+        "MinElements": null,
+        "MaxElements": null,
+        "OrderedBy": null
+      }
+    }
+  },
+  "Exts": [
+    {
+      "Keyword": "some-extension:ext",
+      "Argument": "ext-value"
+    }
+  ],
+  "ListAttr": {
+    "MinElements": {
+      "Name": "48"
+    },
+    "MaxElements": {
+      "Name": "42"
+    },
+    "OrderedBy": null
+  },
+  "Identities": [
+    {
+      "Name": "ID_ONE"
+    }
+  ]
+}`,
+	}}
+
+	for _, tt := range tests {
+		got, err := json.MarshalIndent(tt.in, "", "  ")
+		if err != nil {
+			if !tt.wantErr {
+				t.Errorf("%s: json.MarshalIndent(%v, ...): got unexpected error: %v", tt.name, tt.in, err)
+			}
+			continue
+		}
+
+		if diff := pretty.Compare(string(got), tt.want); diff != "" {
+			t.Errorf("%s: jsonMarshalIndent(%v, ...): did not get expected JSON, diff(-got,+want):\n%s", tt.name, tt.in, diff)
+		}
+	}
+}
+
+func TestParseAndMarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []inputModule
+		want map[string]string
+	}{{
+		name: "simple single module",
+		in: []inputModule{{
+			name: "test.yang",
+			content: `module test {
+											prefix "t";
+											namespace "urn:t";
+
+											typedef foobar {
+												type string {
+													length "10";
+												}
+											}
+
+											identity "BASE";
+											identity "DERIVED" { base "BASE"; }
+
+											container test {
+												list a {
+													key "k";
+													leaf k { type string; }
+
+													leaf bar {
+														type foobar;
+													}
+												}
+
+												leaf d {
+													type decimal64 {
+														fraction-digits 8;
+													}
+												}
+
+												leaf-list zip {
+													type string;
+												}
+
+												leaf x {
+													type union {
+														type string;
+														type identityref {
+															base "BASE";
+														}
+													}
+												}
+											}
+										}`,
+		}},
+		want: map[string]string{
+			"test": `{
+  "Name": "test",
+  "Kind": 1,
+  "Config": 0,
+  "Prefix": {
+    "Name": "t",
+    "Source": {
+      "Keyword": "prefix",
+      "Argument": "t"
+    }
+  },
+  "Dir": {
+    "test": {
+      "Name": "test",
+      "Kind": 1,
+      "Config": 0,
+      "Prefix": {
+        "Name": "t",
+        "Source": {
+          "Keyword": "prefix",
+          "Argument": "t"
+        }
+      },
+      "Dir": {
+        "a": {
+          "Name": "a",
+          "Kind": 1,
+          "Config": 0,
+          "Prefix": {
+            "Name": "t",
+            "Source": {
+              "Keyword": "prefix",
+              "Argument": "t"
+            }
+          },
+          "Dir": {
+            "bar": {
+              "Name": "bar",
+              "Kind": 0,
+              "Config": 0,
+              "Type": {
+                "Name": "foobar",
+                "Kind": 18,
+                "Length": [
+                  {
+                    "Min": {
+                      "Kind": 0,
+                      "Value": 10
+                    },
+                    "Max": {
+                      "Kind": 0,
+                      "Value": 10
+                    }
+                  }
+                ]
+              }
+            },
+            "k": {
+              "Name": "k",
+              "Kind": 0,
+              "Config": 0,
+              "Type": {
+                "Name": "string",
+                "Kind": 18
+              }
+            }
+          },
+          "Key": "k",
+          "ListAttr": {
+            "MinElements": null,
+            "MaxElements": null,
+            "OrderedBy": null
+          }
+        },
+        "d": {
+          "Name": "d",
+          "Kind": 0,
+          "Config": 0,
+          "Type": {
+            "Name": "decimal64",
+            "Kind": 12,
+            "FractionDigits": 8,
+            "Range": [
+              {
+                "Min": {
+                  "Kind": 2,
+                  "Value": 0
+                },
+                "Max": {
+                  "Kind": 3,
+                  "Value": 0
+                }
+              }
+            ]
+          }
+        },
+        "x": {
+          "Name": "x",
+          "Kind": 0,
+          "Config": 0,
+          "Type": {
+            "Name": "union",
+            "Kind": 19,
+            "Type": [
+              {
+                "Name": "string",
+                "Kind": 18
+              },
+              {
+                "Name": "identityref",
+                "Kind": 15,
+                "IdentityBase": {
+                  "Name": "BASE",
+                  "Values": [
+                    {
+                      "Name": "DERIVED"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "zip": {
+          "Name": "zip",
+          "Kind": 0,
+          "Config": 0,
+          "Type": {
+            "Name": "string",
+            "Kind": 18
+          },
+          "ListAttr": {
+            "MinElements": null,
+            "MaxElements": null,
+            "OrderedBy": null
+          }
+        }
+      }
+    }
+  },
+  "Identities": [
+    {
+      "Name": "BASE",
+      "Values": [
+        {
+          "Name": "DERIVED"
+        }
+      ]
+    },
+    {
+      "Name": "DERIVED"
+    }
+  ]
+}`,
+		},
+	}, {
+		name: "multiple modules with extension",
+		in: []inputModule{{
+			name: "ext.yang",
+			content: `module ext {
+										prefix "e";
+										namespace "urn:e";
+
+										extension foobar {
+											argument "baz";
+										}
+									}`,
+		}, {
+			name: "test.yang",
+			content:`module test {
+											prefix "t";
+											namespace "urn:t";
+
+											import ext { prefix ext; }
+
+											leaf t {
+												type string;
+												ext:foobar "marked";
+											}
+										}`,
+			}},
+		want: map[string]string{
+			"test": `{
+  "Name": "test",
+  "Kind": 1,
+  "Config": 0,
+  "Prefix": {
+    "Name": "t",
+    "Source": {
+      "Keyword": "prefix",
+      "Argument": "t"
+    }
+  },
+  "Dir": {
+    "t": {
+      "Name": "t",
+      "Kind": 0,
+      "Config": 0,
+      "Type": {
+        "Name": "string",
+        "Kind": 18
+      },
+      "Exts": [
+        {
+          "Keyword": "ext:foobar",
+          "Argument": "marked"
+        }
+      ]
+    }
+  }
+}`,
+			"ext": `{
+  "Name": "ext",
+  "Kind": 1,
+  "Config": 0,
+  "Prefix": {
+    "Name": "e",
+    "Source": {
+      "Keyword": "prefix",
+      "Argument": "e"
+    }
+  }
+}`,
+		},
+	}}
+
+	for _, tt := range tests {
+		ms := NewModules()
+
+		for _, mod := range tt.in {
+			if err := ms.Parse(mod.content, mod.name); err != nil {
+				t.Errorf("%s: ms.Parse(..., %v): parsing error with module: %v", tt.name, mod.name, err)
+				continue
+			}
+
+			if errs := ms.Process(); len(errs) != 0 {
+				t.Errorf("%s: ms.Process(): could not parse modules: %v", tt.name, errs)
+				continue
+			}
+
+			entries := make(map[string]*Entry)
+			for _, m := range ms.Modules {
+				if _, ok := entries[m.Name]; !ok {
+					entries[m.Name] = ToEntry(m)
+
+					got, err := json.MarshalIndent(entries[m.Name], "", "  ")
+					if err != nil {
+						t.Errorf("%s: json.MarshalIndent(...): got unexpected error: %v", tt.name, err)
+						continue
+					}
+
+					if diff := pretty.Compare(string(got), tt.want[m.Name]); diff != "" {
+						t.Errorf("%s: json.MarshalIndent(...): did not get expected JSON, diff(-got,+want):\n%s", tt.name, diff)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -45,6 +45,7 @@ func TestMarshalJSON(t *testing.T) {
 				Source: &Statement{
 					Keyword:  "prefix",
 					Argument: "ModulePrefix",
+          HasArgument: true,
 				},
 			},
 			Type: &YangType{
@@ -63,6 +64,7 @@ func TestMarshalJSON(t *testing.T) {
     "Name": "ModulePrefix",
     "Source": {
       "Keyword": "prefix",
+      "HasArgument": true,
       "Argument": "ModulePrefix"
     }
   },
@@ -86,6 +88,7 @@ func TestMarshalJSON(t *testing.T) {
 				Source: &Statement{
 					Keyword:  "prefix",
 					Argument: "ModulePrefix",
+          HasArgument: true,
 				},
 			},
 			Dir: map[string]*Entry{
@@ -101,6 +104,7 @@ func TestMarshalJSON(t *testing.T) {
 						Source: &Statement{
 							Keyword:  "prefix",
 							Argument: "ModulePrefix",
+              HasArgument: true,
 						},
 					},
 					Type: &YangType{
@@ -126,6 +130,7 @@ func TestMarshalJSON(t *testing.T) {
     "Name": "ModulePrefix",
     "Source": {
       "Keyword": "prefix",
+      "HasArgument": true,
       "Argument": "ModulePrefix"
     }
   },
@@ -138,6 +143,7 @@ func TestMarshalJSON(t *testing.T) {
         "Name": "ModulePrefix",
         "Source": {
           "Keyword": "prefix",
+          "HasArgument": true,
           "Argument": "ModulePrefix"
         }
       },
@@ -199,6 +205,7 @@ func TestMarshalJSON(t *testing.T) {
 			Exts: []*Statement{{
 				Keyword:  "some-extension:ext",
 				Argument: "ext-value",
+        HasArgument: true,
 			}},
 		},
 		want: `{
@@ -225,6 +232,7 @@ func TestMarshalJSON(t *testing.T) {
   "Exts": [
     {
       "Keyword": "some-extension:ext",
+      "HasArgument": true,
       "Argument": "ext-value"
     }
   ],
@@ -322,6 +330,7 @@ func TestParseAndMarshal(t *testing.T) {
     "Name": "t",
     "Source": {
       "Keyword": "prefix",
+      "HasArgument": true,
       "Argument": "t"
     }
   },
@@ -334,6 +343,7 @@ func TestParseAndMarshal(t *testing.T) {
         "Name": "t",
         "Source": {
           "Keyword": "prefix",
+          "HasArgument": true,
           "Argument": "t"
         }
       },
@@ -346,6 +356,7 @@ func TestParseAndMarshal(t *testing.T) {
             "Name": "t",
             "Source": {
               "Keyword": "prefix",
+              "HasArgument": true,
               "Argument": "t"
             }
           },
@@ -504,6 +515,7 @@ func TestParseAndMarshal(t *testing.T) {
     "Name": "t",
     "Source": {
       "Keyword": "prefix",
+      "HasArgument": true,
       "Argument": "t"
     }
   },
@@ -519,6 +531,7 @@ func TestParseAndMarshal(t *testing.T) {
       "Exts": [
         {
           "Keyword": "ext:foobar",
+          "HasArgument": true,
           "Argument": "marked"
         }
       ]
@@ -533,6 +546,7 @@ func TestParseAndMarshal(t *testing.T) {
     "Name": "e",
     "Source": {
       "Keyword": "prefix",
+      "HasArgument": true,
       "Argument": "e"
     }
   }

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -48,9 +48,9 @@ type parser struct {
 // A Statement is a generic YANG statement.  A Statement may have optional
 // sub-statement (i.e., a Statement is a tree).
 type Statement struct {
-	keyword     string
+	Keyword     string
 	hasArgument bool
-	argument    string
+	Argument    string
 	statements  []*Statement
 
 	file string
@@ -61,7 +61,7 @@ type Statement struct {
 // FakeStatement returns a statement filled in with keyword, file, line and col.
 func FakeStatement(keyword, file string, line, col int) *Statement {
 	return &Statement{
-		keyword: keyword,
+		Keyword: keyword,
 		file:    file,
 		line:    line,
 		col:     col,
@@ -70,18 +70,18 @@ func FakeStatement(keyword, file string, line, col int) *Statement {
 
 // Make Statement statisfy Node
 
-func (s *Statement) NName() string         { return s.argument }
-func (s *Statement) Kind() string          { return s.keyword }
+func (s *Statement) NName() string         { return s.Argument }
+func (s *Statement) Kind() string          { return s.Keyword }
 func (s *Statement) Statement() *Statement { return s }
 func (s *Statement) ParentNode() Node      { return nil }
 func (s *Statement) Exts() []*Statement    { return nil }
 
 // Arg returns the optional argument to s.  It returns false if s has no
 // argument.
-func (s *Statement) Arg() (string, bool) { return s.argument, s.hasArgument }
+func (s *Statement) Arg() (string, bool) { return s.Argument, s.hasArgument }
 
 // Keyword returns the keyword of s.
-func (s *Statement) Keyword() string { return s.keyword }
+//func (s *Statement) Keyword() string { return s.Keyword }
 
 // SubStatements returns a slice of Statements found in s.
 func (s *Statement) SubStatements() []*Statement { return s.statements }
@@ -112,7 +112,7 @@ func (s *Statement) Location() string {
 // level.  Write is intended to display the contents of Statement, but
 // not necessarily reproduce the input of Statement.
 func (s *Statement) Write(w io.Writer, indent string) error {
-	if s.keyword == "" {
+	if s.Keyword == "" {
 		// We are just a collection of statements at the top level.
 		for _, s := range s.statements {
 			if err := s.Write(w, indent); err != nil {
@@ -122,14 +122,14 @@ func (s *Statement) Write(w io.Writer, indent string) error {
 		return nil
 	}
 
-	parts := []string{fmt.Sprintf("%s%s", indent, s.keyword)}
+	parts := []string{fmt.Sprintf("%s%s", indent, s.Keyword)}
 	if s.hasArgument {
-		args := strings.Split(s.argument, "\n")
+		args := strings.Split(s.Argument, "\n")
 		if len(args) == 1 {
-			parts = append(parts, fmt.Sprintf(" %q", s.argument))
+			parts = append(parts, fmt.Sprintf(" %q", s.Argument))
 		} else {
 			parts = append(parts, ` "`, args[0], "\n")
-			i := fmt.Sprintf("%*s", len(s.keyword)+1, "")
+			i := fmt.Sprintf("%*s", len(s.Keyword)+1, "")
 			for x, p := range args[1:] {
 				s := fmt.Sprintf("%q", p)
 				s = s[1 : len(s)-1]
@@ -284,7 +284,7 @@ func (p *parser) nextStatement() *Statement {
 	}
 
 	s := &Statement{
-		keyword: t.Text,
+		Keyword: t.Text,
 		file:    t.File,
 		line:    t.Line,
 		col:     t.Col,
@@ -299,7 +299,7 @@ func (p *parser) nextStatement() *Statement {
 	switch t.Code() {
 	case tString, tIdentifier:
 		s.hasArgument = true
-		s.argument = t.Text
+		s.Argument = t.Text
 		t = p.next()
 	}
 	switch t.Code() {

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -49,7 +49,7 @@ type parser struct {
 // sub-statement (i.e., a Statement is a tree).
 type Statement struct {
 	Keyword     string
-	hasArgument bool
+	HasArgument bool
 	Argument    string
 	statements  []*Statement
 
@@ -78,7 +78,7 @@ func (s *Statement) Exts() []*Statement    { return nil }
 
 // Arg returns the optional argument to s.  It returns false if s has no
 // argument.
-func (s *Statement) Arg() (string, bool) { return s.Argument, s.hasArgument }
+func (s *Statement) Arg() (string, bool) { return s.Argument, s.HasArgument }
 
 // Keyword returns the keyword of s.
 //func (s *Statement) Keyword() string { return s.Keyword }
@@ -123,7 +123,7 @@ func (s *Statement) Write(w io.Writer, indent string) error {
 	}
 
 	parts := []string{fmt.Sprintf("%s%s", indent, s.Keyword)}
-	if s.hasArgument {
+	if s.HasArgument {
 		args := strings.Split(s.Argument, "\n")
 		if len(args) == 1 {
 			parts = append(parts, fmt.Sprintf(" %q", s.Argument))
@@ -298,7 +298,7 @@ func (p *parser) nextStatement() *Statement {
 	p.lex.inPattern = false
 	switch t.Code() {
 	case tString, tIdentifier:
-		s.hasArgument = true
+		s.HasArgument = true
 		s.Argument = t.Text
 		t = p.next()
 	}

--- a/pkg/yang/parse_test.go
+++ b/pkg/yang/parse_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func (s1 *Statement) equal(s2 *Statement) bool {
-	if s1.keyword != s2.keyword ||
+	if s1.Keyword != s2.Keyword ||
 		s1.hasArgument != s2.hasArgument ||
-		s1.argument != s2.argument ||
+		s1.Argument != s2.Argument ||
 		len(s1.statements) != len(s2.statements) {
 		return false
 	}
@@ -38,8 +38,8 @@ func (s1 *Statement) equal(s2 *Statement) bool {
 // SA returns a statment with an argument and optional substatements.
 func SA(k, a string, ss ...*Statement) *Statement {
 	return &Statement{
-		keyword:     k,
-		argument:    a,
+		Keyword:     k,
+		Argument:    a,
 		hasArgument: true,
 		statements:  ss,
 	}
@@ -48,7 +48,7 @@ func SA(k, a string, ss ...*Statement) *Statement {
 // S returns a statment with no argument and optional substatements.
 func S(k string, ss ...*Statement) *Statement {
 	return &Statement{
-		keyword:    k,
+		Keyword:    k,
 		statements: ss,
 	}
 }
@@ -105,7 +105,7 @@ foo "\\ \S \n";
 pattern "\\ \S \n";
 `,
 			out: []*Statement{
-				SA("pattern", `\\ \S 
+        SA("pattern", `\\ \S 
 `),
 			},
 		},

--- a/pkg/yang/parse_test.go
+++ b/pkg/yang/parse_test.go
@@ -21,7 +21,7 @@ import (
 
 func (s1 *Statement) equal(s2 *Statement) bool {
 	if s1.Keyword != s2.Keyword ||
-		s1.hasArgument != s2.hasArgument ||
+		s1.HasArgument != s2.HasArgument ||
 		s1.Argument != s2.Argument ||
 		len(s1.statements) != len(s2.statements) {
 		return false
@@ -40,7 +40,7 @@ func SA(k, a string, ss ...*Statement) *Statement {
 	return &Statement{
 		Keyword:     k,
 		Argument:    a,
-		hasArgument: true,
+		HasArgument: true,
 		statements:  ss,
 	}
 }
@@ -105,7 +105,7 @@ foo "\\ \S \n";
 pattern "\\ \S \n";
 `,
 			out: []*Statement{
-        SA("pattern", `\\ \S 
+				SA("pattern", `\\ \S 
 `),
 			},
 		},

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -248,20 +248,20 @@ func (e *EnumType) ValueMap() map[int64]string {
 type YangType struct {
 	Name             string
 	Kind             TypeKind    // Ynone if not a base type
-	Base             *Type       `json:"-"` // Base type for non-builtin types
-	IdentityBase     *Identity   // Base statement for a type using identityref
-	Root             *YangType   `json:"-"` // root of this type that is the same
-	Bit              *EnumType   // bit position, "status" is lost
-	Enum             *EnumType   // enum name to value, "status" is lost
-	Units            string      // units to be used for this type
-	Default          string      // default value, if any
-	FractionDigits   int         // decimal64 fixed point precision
-	Length           YangRange   // this should be processed by section 12
-	OptionalInstance bool        // !require-instances which defaults to true
-	Path             string      // the path in a leafref
-	Pattern          []string    // limiting XSD-TYPES expressions on strings
-	Range            YangRange   // range for integers
-	Type             []*YangType `json:"-"` // for unions
+	Base             *Type       `json:"-"`          // Base type for non-builtin types
+	IdentityBase     *Identity   `json:",omitempty"` // Base statement for a type using identityref
+	Root             *YangType   `json:"-"`          // root of this type that is the same
+	Bit              *EnumType   `json:",omitempty"` // bit position, "status" is lost
+	Enum             *EnumType   `json:",omitempty"` // enum name to value, "status" is lost
+	Units            string      `json:",omitempty"` // units to be used for this type
+	Default          string      `json:",omitempty"` // default value, if any
+	FractionDigits   int         `json:",omitempty"` // decimal64 fixed point precision
+	Length           YangRange   `json:",omitempty"` // this should be processed by section 12
+	OptionalInstance bool        `json:",omitempty"` // !require-instances which defaults to true
+	Path             string      `json:",omitempty"` // the path in a leafref
+	Pattern          []string    `json:",omitempty"` // limiting XSD-TYPES expressions on strings
+	Range            YangRange   `json:",omitempty"` // range for integers
+	Type             []*YangType `json:",omitempty"` // for unions
 }
 
 // BaseTypedefs is a map of all base types to the Typedef structure manufactured

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -27,11 +27,11 @@ import "fmt"
 // A Value is just a string that can have extensions.
 type Value struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:",omitempty"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
-	Description *Value `yang:"description"`
+	Description *Value `yang:"description" json:",omitempty"`
 }
 
 func (Value) Kind() string             { return "string" }
@@ -765,15 +765,15 @@ func (s *Augment) Exts() []*Statement    { return s.Extensions }
 // An Identity is defined in: http://tools.ietf.org/html/rfc6020#section-7.16
 type Identity struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:"-"`
 
-	Base        *Value `yang:"base"`
-	Description *Value `yang:"description"`
-	Reference   *Value `yang:"reference"`
-	Status      *Value `yang:"status"`
-	Values      []*Identity
+	Base        *Value      `yang:"base" json:"-"`
+	Description *Value      `yang:"description" json:"-"`
+	Reference   *Value      `yang:"reference" json:"-"`
+	Status      *Value      `yang:"status" json:"-"`
+	Values      []*Identity `json:",omitempty"`
 }
 
 func (Identity) Kind() string             { return "identity" }


### PR DESCRIPTION
```  
* (M) pkg/yang/ast.go:
  * (M) pkg/yang/parse_test.go:
  * (M) pkg/yang/parse.go:
   - Adopt changes to the Statement type such that Keyword and Argument
     are now public members of the struct. This is used in the case that
     an extension is defined to allow an external consumer to be able to
     determine these values by the value of the fields rather than the
     helper methods. Allows this information to be marshalled to JSON.
  * (M) pkg/yang/entry.go:
   - Add JSON annotations to the entry struct to ensure that there are
     no loops when marshalling an Entry. Explicitly excludes the Parent
     field since this results in circular references
     (parent.Dir[child].Parent == parent). Adds omitempty annotations to
     reduce JSON size.
  * (M) pkg/yang/types_builtin.go:
   - Add annotations to the YangType struct such that it can be
     marshalled to JSON.
  * (M) pkg/yang/yang.go:
   - Add annotations to the Value struct such that it can be marshalled.
  * (M) pkg/yang/marshal_test.go
   - Add test cases for marshalling to JSON.
```