### PR TITLE
yang: Add support for YANG 1.1 "anydata" statement

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -168,6 +168,7 @@ type EntryKind int
 const (
 	LeafEntry = EntryKind(iota)
 	DirectoryEntry
+	AnyDataEntry
 	AnyXMLEntry
 	CaseEntry
 	ChoiceEntry
@@ -180,6 +181,7 @@ const (
 var EntryKindToName = map[EntryKind]string{
 	LeafEntry:         "Leaf",
 	DirectoryEntry:    "Directory",
+	AnyDataEntry:      "AnyData",
 	AnyXMLEntry:       "AnyXML",
 	CaseEntry:         "Case",
 	ChoiceEntry:       "Choice",
@@ -442,6 +444,8 @@ func ToEntry(n Node) (e *Entry) {
 		}
 	case *Case:
 		e.Kind = CaseEntry
+	case *AnyData:
+		e.Kind = AnyDataEntry
 	case *AnyXML:
 		e.Kind = AnyXMLEntry
 	case *Input:
@@ -485,6 +489,10 @@ func ToEntry(n Node) (e *Entry) {
 				ne := ToEntry(a)
 				ne.Parent = e
 				e.Augments = append(e.Augments, ne)
+			}
+		case "anydata":
+			for _, a := range fv.Interface().([]*AnyData) {
+				e.add(a.Name, ToEntry(a))
 			}
 		case "anyxml":
 			for _, a := range fv.Interface().([]*AnyXML) {

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -105,6 +105,7 @@ type Module struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata      []*AnyData      `yang:"anydata"`
 	Anyxml       []*AnyXML       `yang:"anyxml"`
 	Augment      []*Augment      `yang:"augment"`
 	BelongsTo    *BelongsTo      `yang:"belongs-to,required=submodule,nomerge"`
@@ -335,6 +336,7 @@ type Container struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Choice      []*Choice    `yang:"choice"`
 	Config      *Value       `yang:"config"`
@@ -442,6 +444,7 @@ type List struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Choice      []*Choice    `yang:"choice"`
 	Config      *Value       `yang:"config"`
@@ -480,6 +483,7 @@ type Choice struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Case        []*Case      `yang:"case"`
 	Config      *Value       `yang:"config"`
@@ -509,6 +513,7 @@ type Case struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Choice      []*Choice    `yang:"choice"`
 	Container   []*Container `yang:"container"`
@@ -552,6 +557,32 @@ func (s *AnyXML) NName() string         { return s.Name }
 func (s *AnyXML) Statement() *Statement { return s.Source }
 func (s *AnyXML) Exts() []*Statement    { return s.Extensions }
 
+// An AnyData is defined in: http://tools.ietf.org/html/rfc7950#section-7.10
+//
+// AnyData are only expected in YANG 1.1 modules (those with a
+// "yang-version 1.1;" statement in the module).
+type AnyData struct {
+	Name       string       `yang:"Name,nomerge"`
+	Source     *Statement   `yang:"Statement,nomerge"`
+	Parent     Node         `yang:"Parent,nomerge"`
+	Extensions []*Statement `yang:"Ext"`
+
+	Config      *Value   `yang:"config"`
+	Description *Value   `yang:"description"`
+	IfFeature   []*Value `yang:"if-feature"`
+	Mandatory   *Value   `yang:"mandatory"`
+	Must        []*Must  `yang:"must"`
+	Reference   *Value   `yang:"reference"`
+	Status      *Value   `yang:"status"`
+	When        *Value   `yang:"when"`
+}
+
+func (AnyData) Kind() string             { return "anydata" }
+func (s *AnyData) ParentNode() Node      { return s.Parent }
+func (s *AnyData) NName() string         { return s.Name }
+func (s *AnyData) Statement() *Statement { return s.Source }
+func (s *AnyData) Exts() []*Statement    { return s.Extensions }
+
 // A Grouping is defined in: http://tools.ietf.org/html/rfc6020#section-7.11
 type Grouping struct {
 	Name       string       `yang:"Name,nomerge"`
@@ -559,6 +590,7 @@ type Grouping struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Choice      []*Choice    `yang:"choice"`
 	Container   []*Container `yang:"container"`
@@ -659,6 +691,7 @@ type Input struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata   []*AnyData   `yang:"anydata"`
 	Anyxml    []*AnyXML    `yang:"anyxml"`
 	Choice    []*Choice    `yang:"choice"`
 	Container []*Container `yang:"container"`
@@ -685,6 +718,7 @@ type Output struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata   []*AnyData   `yang:"anydata"`
 	Anyxml    []*AnyXML    `yang:"anyxml"`
 	Choice    []*Choice    `yang:"choice"`
 	Container []*Container `yang:"container"`
@@ -711,6 +745,7 @@ type Notification struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Choice      []*Choice    `yang:"choice"`
 	Container   []*Container `yang:"container"`
@@ -741,6 +776,7 @@ type Augment struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
+	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Case        []*Case      `yang:"case"`
 	Choice      []*Choice    `yang:"choice"`


### PR DESCRIPTION
Support reading the YANG 1.1 "anydata" statement.

The "anydata" statement is defined at:
https://tools.ietf.org/html/rfc7950#section-7.10

Prior to this change, the presence of an "anydata"
sub-statement in YANG modules leads to errors such as:

```
ietf-restconf.yang:196:9: unknown list field: anydata
ietf-yang-patch.yang:263:9: unknown list field: anydata
```

The "anydata" statement is a YANG data node statement, similar
in nature to the YANG 1.0 "anyxml" statement. It stores an
opaque value whose use and encoding is agreed upon apriori
between parties using the field.

Add lexing tests for the "anydata" and "anyxml" statements.

Resolves #46.