### PR TITLE
Add an Annotation field to yang.Entry.

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -97,6 +97,11 @@ type Entry struct {
 
 	// Extra maps all the unsupported fields to their values
 	Extra map[string][]interface{} `json:"-"`
+
+	// Annotation stores annotated values, and is not populated by this
+	// library but rather can be used by calling code where additional
+	// information should be stored alongside the Entry.
+	Annotation map[string]interface{} `json:",omitempty"`
 }
 
 // An RPCEntry contains information related to an RPC Node.

--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -43,15 +43,18 @@ func TestMarshalJSON(t *testing.T) {
 			Prefix: &Value{
 				Name: "ModulePrefix",
 				Source: &Statement{
-					Keyword:  "prefix",
-					Argument: "ModulePrefix",
-          HasArgument: true,
+					Keyword:     "prefix",
+					Argument:    "ModulePrefix",
+					HasArgument: true,
 				},
 			},
 			Type: &YangType{
 				Name:    "string",
 				Kind:    Ystring,
 				Default: "string-value",
+			},
+			Annotation: map[string]interface{}{
+				"fish": struct{ Side string }{"chips"},
 			},
 		},
 		want: `{
@@ -72,6 +75,11 @@ func TestMarshalJSON(t *testing.T) {
     "Name": "string",
     "Kind": 18,
     "Default": "string-value"
+  },
+  "Annotation": {
+    "fish": {
+      "Side": "chips"
+    }
   }
 }`,
 	}, {
@@ -86,9 +94,9 @@ func TestMarshalJSON(t *testing.T) {
 			Prefix: &Value{
 				Name: "ModulePrefix",
 				Source: &Statement{
-					Keyword:  "prefix",
-					Argument: "ModulePrefix",
-          HasArgument: true,
+					Keyword:     "prefix",
+					Argument:    "ModulePrefix",
+					HasArgument: true,
 				},
 			},
 			Dir: map[string]*Entry{
@@ -102,9 +110,9 @@ func TestMarshalJSON(t *testing.T) {
 					Prefix: &Value{
 						Name: "ModulePrefix",
 						Source: &Statement{
-							Keyword:  "prefix",
-							Argument: "ModulePrefix",
-              HasArgument: true,
+							Keyword:     "prefix",
+							Argument:    "ModulePrefix",
+							HasArgument: true,
 						},
 					},
 					Type: &YangType{
@@ -203,9 +211,9 @@ func TestMarshalJSON(t *testing.T) {
 				Name: "ID_ONE",
 			}},
 			Exts: []*Statement{{
-				Keyword:  "some-extension:ext",
-				Argument: "ext-value",
-        HasArgument: true,
+				Keyword:     "some-extension:ext",
+				Argument:    "ext-value",
+				HasArgument: true,
 			}},
 		},
 		want: `{
@@ -494,7 +502,7 @@ func TestParseAndMarshal(t *testing.T) {
 									}`,
 		}, {
 			name: "test.yang",
-			content:`module test {
+			content: `module test {
 											prefix "t";
 											namespace "urn:t";
 
@@ -505,7 +513,7 @@ func TestParseAndMarshal(t *testing.T) {
 												ext:foobar "marked";
 											}
 										}`,
-			}},
+		}},
 		want: map[string]string{
 			"test": `{
   "Name": "test",


### PR DESCRIPTION
In some cases, it is useful for an application storing or using `yang.Entry` structs to store some additional information with them. Whilst one could overload the `Extra` field, this may contain types which do not cleanly marshal, and is really intended for extra YANG statements. This PR adds an `Annotation` field to the `Entry` struct, that a calling application can append data it wishes to store alongside the `yang.Entry` to.

```
 * (M) pkg/yang/entry.go
   - Add an annotation field to the yang.Entry consisting of a
     map[string]interface{} such that a calling application can
     store arbitrary data alongside the yang.Entry for serialisation.
 * (M) pkg/yang/marshal_test.go
   - Add test for Annotation field.
```