### PR TITLE
Handle mismatched import prefixes in Entry.Find()

### DIFF
--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1082,6 +1082,7 @@ func TestEntryFind(t *testing.T) {
 
 					leaf ctx { type string; }
 					leaf other { type string; }
+					leaf conflict { type string; }
 				}`,
 			"foo.yang": `
 				module foo {
@@ -1091,6 +1092,8 @@ func TestEntryFind(t *testing.T) {
 					container bar {
 						leaf baz { type string; }
 					}
+
+					leaf conflict { type string; }
 				}`,
 			"bar.yang": `
 				module bar {
@@ -1100,6 +1103,8 @@ func TestEntryFind(t *testing.T) {
 					container fish {
 						leaf chips { type string; }
 					}
+
+					leaf conflict { type string; }
 				}`,
 		},
 		inBaseEntryPath: "/test/ctx",
@@ -1113,6 +1118,11 @@ func TestEntryFind(t *testing.T) {
 			"/foo:bar/baz": "/foo/bar/baz",
 			// With mismatched prefixes.
 			"/baz:fish/baz:chips": "/bar/fish/chips",
+			// With conflicting node names
+			"/conflict":     "/test/conflict",
+			"/foo:conflict": "/foo/conflict",
+			"/baz:conflict": "/bar/conflict",
+			"/t:conflict":   "/test/conflict",
 		},
 	}}
 


### PR DESCRIPTION
```
 * (M) pkg/yang/entry.go
   - In YANG we can have module A, defining prefix A, imported by
     module B which imports it using its own prefix FOOBAR. In this
     case then Find() for an Entry would assume that it can use
     FOOBAR to find A within the module set that was being worked on.
     This change catalogues the imports of module B, such that there
     is a mapping between FOOBAR->A, and looks up the module using
     the prefix A.
 * (M) pkg/yang/entry_test.go
  - Enhance unit test coverage for Find, including the above case.
    We are a little more liberal than the spec says that we can be
    such that we do not error if there is /foo:bar/baz and baz
    exists within the module prefixed foo.
```