### PR TITLE
Fix up Number parsing, displaying and fix build error.

### DIFF
--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"google3/third_party/golang/godebug/pretty/pretty"
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestMarshalJSON(t *testing.T) {

--- a/pkg/yang/number_test.go
+++ b/pkg/yang/number_test.go
@@ -56,6 +56,10 @@ func TestNumberParse(t *testing.T) {
 		numString: ".123",
 		want:      Number{Kind: Positive, Value: 123, FractionDigits: 3},
 	}, {
+		desc:      "+ve float, leading 0",
+		numString: "0.123",
+		want:      Number{Kind: Positive, Value: 123, FractionDigits: 3},
+	}, {
 		desc:      "-ve float",
 		numString: "-123.123",
 		want:      Number{Kind: Negative, Value: 123123, FractionDigits: 3},
@@ -112,7 +116,15 @@ func TestNumberParse(t *testing.T) {
 		if got, want := n, tt.want; tt.wantErr == "" && !got.Equal(want) {
 			t.Errorf("%s: got: %v, want: %v", tt.desc, got, want)
 		}
-
+		if err == nil {
+			want := tt.numString
+			if want[0] == '.' {
+				want = "0" + want
+			}
+			if got := n.String(); got != want {
+				t.Errorf("%s: got %q, want %q", tt.desc, got, want)
+			}
+		}
 	}
 }
 

--- a/pkg/yang/number_test.go
+++ b/pkg/yang/number_test.go
@@ -60,6 +60,14 @@ func TestNumberParse(t *testing.T) {
 		numString: "0.123",
 		want:      Number{Kind: Positive, Value: 123, FractionDigits: 3},
 	}, {
+		desc:      "-ve float, small value",
+		numString: "-0.0123",
+		want:      Number{Kind: Negative, Value: 123, FractionDigits: 4},
+	}, {
+		desc:      "+ve float, small value",
+		numString: "0.0123",
+		want:      Number{Kind: Positive, Value: 123, FractionDigits: 4},
+	}, {
 		desc:      "-ve float",
 		numString: "-123.123",
 		want:      Number{Kind: Negative, Value: 123123, FractionDigits: 3},

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -603,10 +603,8 @@ func DecimalValueFromString(numStr string, fracDigRequired int) (n Number, err e
 
 // String returns n as a string in decimal.
 func (n Number) String() string {
-	out := ""
+	var out string
 	switch n.Kind {
-	case Negative:
-		out += "-"
 	case MinNumber:
 		return "min"
 	case MaxNumber:
@@ -621,11 +619,14 @@ func (n Number) String() string {
 			ofd := len(out) - fd
 			if ofd <= 0 {
 				// We want 0.1 not .1
-				out = space18[:ofd+1] + out
+				out = space18[:-ofd+1] + out
 				ofd = 1
 			}
 			out = out[:ofd] + "." + out[ofd:]
 		}
+	}
+	if n.Kind == Negative {
+		out = "-" + out
 	}
 
 	return out


### PR DESCRIPTION
marshal_test.go was including pretty from the internal Google repository.

Parsing the number "0.123" resulted in 0.083 as the leading 0 cause
the parse to be in octal.

Displaying the string ".1" into a Decimal number paniced.

Display "0.1" not ".1"