### PR TITLE
Fix handling for empty container schema entries.

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -149,7 +149,7 @@ func (e *Entry) IsList() bool {
 
 // IsContainer returns true if e is a container.
 func (e *Entry) IsContainer() bool {
-	return e.IsDir() && e.ListAttr == nil && e.Kind != ChoiceEntry && e.Kind != CaseEntry
+	return e.Kind == DirectoryEntry && e.ListAttr == nil
 }
 
 // IsChoice returns true if the entry is a choice node within the schema.

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1182,6 +1182,11 @@ func TestEntryTypes(t *testing.T) {
 		},
 	}
 
+	emptyContainerSchema := &Entry{
+		Name: "empty-container-schema",
+		Kind: DirectoryEntry,
+	}
+
 	leafListSchema := &Entry{
 		Kind:     LeafEntry,
 		ListAttr: &ListAttr{MinElements: &Value{Name: "0"}},
@@ -1243,6 +1248,11 @@ func TestEntryTypes(t *testing.T) {
 		{
 			desc:     "container",
 			schema:   containerSchema,
+			wantType: Container,
+		},
+		{
+			desc:     "empty container",
+			schema:   emptyContainerSchema,
 			wantType: Container,
 		},
 		{


### PR DESCRIPTION
The current test checks for the existence of Dir in Entry, but this can be nil if the container does not have any entries. A more robust check is to test if Kind is DirectoryEntry but the entry is not a list type i.e. does not have list attributes.