### PR TITLE
Resolve bug with namespace identification for augmented nodes

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -913,6 +913,24 @@ func (e *Entry) Namespace() *Value {
 	return new(Value)
 }
 
+// InstantiatingModule returns the YANG module which instanitated the Entry
+// within the schema tree - using the same rules described in the documentation
+// of the Namespace function. The namespace is resolved in the module name. This
+// approach to namespacing is used when serialising YANG-modelled data to JSON as
+// per RFC7951.
+func (e *Entry) InstantiatingModule() (string, error) {
+	n := e.Namespace()
+	if n == nil {
+		return "", fmt.Errorf("entry %s had nil namespace", e.Name)
+	}
+
+	ns, err := e.Modules().FindModuleByNamespace(n.Name)
+	if err != nil {
+		return "", fmt.Errorf("could not find module %s when retrieving namespace for %s", n.Name, e.Name)
+	}
+	return ns.Name, nil
+}
+
 // dup makes a deep duplicate of e.
 func (e *Entry) dup() *Entry {
 	// Warning: if we add any elements to Entry that should not be

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -102,6 +102,13 @@ type Entry struct {
 	// library but rather can be used by calling code where additional
 	// information should be stored alongside the Entry.
 	Annotation map[string]interface{} `json:",omitempty"`
+
+	// namespace stores the namespace of the Entry if it overrides the
+	// root namespace within the schema tree. This is the case where an
+	// entry is augmented into the tree, and it retains the namespace of
+	// the augmenting entity per RFC6020 Section 7.15.2. The namespace
+	// of the Entry should be accessed using the Namespace function.
+	namespace *Value
 }
 
 // An RPCEntry contains information related to an RPC Node.
@@ -600,7 +607,7 @@ func ToEntry(n Node) (e *Entry) {
 					}
 					mergedSubmodule[srcToIncluded] = true
 					mergedSubmodule[includedToParent] = true
-					e.merge(a.Module.Prefix, ToEntry(a.Module))
+					e.merge(a.Module.Prefix, nil, ToEntry(a.Module))
 				case ParseOptions.IgnoreSubmoduleCircularDependencies:
 					continue
 				default:
@@ -659,7 +666,7 @@ func ToEntry(n Node) (e *Entry) {
 			}
 		case "uses":
 			for _, a := range fv.Interface().([]*Uses) {
-				e.merge(nil, ToEntry(a))
+				e.merge(nil, nil, ToEntry(a))
 			}
 		case "type":
 			// We don't expect this to happen, so throw an error.
@@ -752,8 +759,11 @@ func (e *Entry) Augment(addErrors bool) (processed, skipped int) {
 			continue
 		}
 		// Augments do not have a prefix we merge in, just a node.
+		// We retain the namespace from the original context of the
+		// augment since the nodes have this namespace even though they
+		// are merged into another entry.
 		processed++
-		ae.merge(nil, a)
+		ae.merge(nil, a.Namespace(), a)
 	}
 	e.Augments = sa
 	return processed, skipped
@@ -887,6 +897,9 @@ func (e *Entry) Path() string {
 func (e *Entry) Namespace() *Value {
 	// Make e the root parent entry
 	for ; e.Parent != nil; e = e.Parent {
+		if e.namespace != nil {
+			return e.namespace
+		}
 	}
 
 	// Return the namespace of a valid root parent entry
@@ -925,12 +938,15 @@ func (e *Entry) dup() *Entry {
 // merge merges a duplicate of oe.Dir into e.Dir, setting the prefix of each
 // element to prefix, if not nil.  It is an error if e and oe contain common
 // elements.
-func (e *Entry) merge(prefix *Value, oe *Entry) {
+func (e *Entry) merge(prefix *Value, namespace *Value, oe *Entry) {
 	e.importErrors(oe)
 	for k, v := range oe.Dir {
 		v := v.dup()
 		if prefix != nil {
 			v.Prefix = prefix
+		}
+		if namespace != nil {
+			v.namespace = namespace
 		}
 		if se := e.Dir[k]; se != nil {
 			er := newError(oe.Node, `Duplicate node %q in %q from:

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -200,6 +200,9 @@ module baz {
 
   grouping baz-common {
     leaf baz-common-leaf { type string; }
+    container baz-dir {
+      leaf aardvark { type string; }
+    }
   }
 
   augment /f:foo-c {
@@ -290,6 +293,11 @@ func TestEntryNamespace(t *testing.T) {
 		{
 			descr: "leaf directly defined within an augment to foo from baz has baz's namespace",
 			entry: foo.Dir["foo-c"].Dir["baz-direct-leaf"],
+			ns:    "urn:baz",
+		},
+		{
+			descr: "children of a container within an augment to from baz have baz's namespace",
+			entry: foo.Dir["foo-c"].Dir["baz-dir"].Dir["aardvark"],
 			ns:    "urn:baz",
 		},
 	} {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -266,39 +266,46 @@ func TestEntryNamespace(t *testing.T) {
 	bar, _ := ms.GetModule("bar")
 
 	for _, tc := range []struct {
-		descr string
-		entry *Entry
-		ns    string
+		descr   string
+		entry   *Entry
+		ns      string
+		wantMod string
 	}{
 		{
-			descr: "grouping used in foo always have foo's namespace, even if it was defined in bar",
-			entry: foo.Dir["foo-c"].Dir["test1"],
-			ns:    "urn:foo",
+			descr:   "grouping used in foo always have foo's namespace, even if it was defined in bar",
+			entry:   foo.Dir["foo-c"].Dir["test1"],
+			ns:      "urn:foo",
+			wantMod: "foo",
 		},
 		{
-			descr: "grouping defined and used in foo has foo's namespace",
-			entry: foo.Dir["foo-c"].Dir["zzz"],
-			ns:    "urn:foo",
+			descr:   "grouping defined and used in foo has foo's namespace",
+			entry:   foo.Dir["foo-c"].Dir["zzz"],
+			ns:      "urn:foo",
+			wantMod: "foo",
 		},
 		{
-			descr: "grouping defined and used in bar has bar's namespace",
-			entry: bar.Dir["bar-local"].Dir["test1"],
-			ns:    "urn:bar",
+			descr:   "grouping defined and used in bar has bar's namespace",
+			entry:   bar.Dir["bar-local"].Dir["test1"],
+			ns:      "urn:bar",
+			wantMod: "bar",
 		},
 		{
-			descr: "leaf within a used grouping in baz augmented into foo has baz's namespace",
-			entry: foo.Dir["foo-c"].Dir["baz-common-leaf"],
-			ns:    "urn:baz",
+			descr:   "leaf within a used grouping in baz augmented into foo has baz's namespace",
+			entry:   foo.Dir["foo-c"].Dir["baz-common-leaf"],
+			ns:      "urn:baz",
+			wantMod: "baz",
 		},
 		{
-			descr: "leaf directly defined within an augment to foo from baz has baz's namespace",
-			entry: foo.Dir["foo-c"].Dir["baz-direct-leaf"],
-			ns:    "urn:baz",
+			descr:   "leaf directly defined within an augment to foo from baz has baz's namespace",
+			entry:   foo.Dir["foo-c"].Dir["baz-direct-leaf"],
+			ns:      "urn:baz",
+			wantMod: "baz",
 		},
 		{
-			descr: "children of a container within an augment to from baz have baz's namespace",
-			entry: foo.Dir["foo-c"].Dir["baz-dir"].Dir["aardvark"],
-			ns:    "urn:baz",
+			descr:   "children of a container within an augment to from baz have baz's namespace",
+			entry:   foo.Dir["foo-c"].Dir["baz-dir"].Dir["aardvark"],
+			ns:      "urn:baz",
+			wantMod: "baz",
 		},
 	} {
 		nsValue := tc.entry.Namespace()
@@ -306,6 +313,16 @@ func TestEntryNamespace(t *testing.T) {
 			t.Errorf("%s: want namespace %s, got nil", tc.descr, tc.ns)
 		} else if tc.ns != nsValue.Name {
 			t.Errorf("%s: want namespace %s, got %s", tc.descr, tc.ns, nsValue.Name)
+		}
+
+		m, err := tc.entry.InstantiatingModule()
+		if err != nil {
+			t.Errorf("%s: %s.InstantiatingModule(): got unexpected error: %v", tc.descr, tc.entry.Path(), err)
+			continue
+		}
+
+		if m != tc.wantMod {
+			t.Errorf("%s: %s.InstantiatingModule(): did not get expected name, got: %v, want: %v", tc.descr, m, tc.wantMod)
 		}
 	}
 }


### PR DESCRIPTION
According to RFC6020 when we have an `augment` statement then the namespace of nodes that are augmented is that of the augment*ing* module rather than the augment*ed* module. This PR fixes an issue whereby this was not correctly reported by `Namespace()` on an `Entry`.

Additionally, it adds a `InstantiatingModule` method to the `Entry` type such that one can determine the module that instantiated the leaf, for use in RFC7951 JSON serialisation.