### PR TITLE
Entry: DefaultValue improvement

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1079,7 +1079,11 @@ func (e *Entry) DefaultValue() string {
 	if len(e.Default) > 0 {
 		return e.Default
 	} else if typ := e.Type; typ != nil {
-		return typ.Default
+		if leaf, ok := e.Node.(*Leaf); ok {
+			if leaf.Mandatory == nil || leaf.Mandatory == "false" {
+				return typ.Default
+			}
+		}
 	}
 	return ""
 }

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -475,6 +475,10 @@ module defaults {
   }
 
   container defaults {
+    leaf mandatory-default {
+      type string-default;
+      mandatory true;
+    }
     leaf uint32-withdefault {
       type uint32;
       default 13;
@@ -522,6 +526,10 @@ module defaults {
 		},
 		{
 			path: []string{"defaults", "common-nodefault", "string"},
+			want: "",
+		},
+		{
+			path: []string{"defaults", "mandatory-default"},
 			want: "",
 		},
 	} {


### PR DESCRIPTION
An Entry's `DefaultValue()` is constrained by RFC6020 section 7.6.1.,
about a leaf's default value. The final paragraph of section 7.6.1.
says:

```
   If a leaf has a "default" statement, the leaf's default value is
   the value of the "default" statement.  Otherwise, if the leaf's
   type has a default value, and the leaf is not mandatory, then the
   leaf's default value is the type's default value.  In all other
   cases, the leaf does not have a default value.
```

This change implements the second sentence in the above paragraph,
namely only using the typedef's default value when the entry is a
leaf and is not mandatory.