### PR TITLE
Avoid panic when an augment is used in a submodule.

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -830,13 +830,23 @@ func (e *Entry) Find(name string) *Entry {
 		// the prefix that the module itself uses then we need to resolve
 		// the module into its local prefix to find it.
 		pfxMap := map[string]string{
-			// Seed the map with the local module.
-			e.Node.(*Module).Prefix.Name: e.Prefix.Name,
+			// Seed the map with the local module - we use GetPrefix just
+			// in case the module is a submodule.
+			e.Node.(*Module).GetPrefix(): e.Prefix.Name,
 		}
+
 		// Add a map between the prefix used in the import statement, and
 		// the prefix that is used in the module itself.
 		for _, i := range e.Node.(*Module).Import {
-			pfxMap[i.Prefix.Name] = i.Module.Prefix.Name
+			// Resolve the module using the current module set, since we may
+			// not have populated the Module for the entry yet.
+			m, ok := e.Node.(*Module).modules.Modules[i.Name]
+			if !ok {
+				e.addError(fmt.Errorf("cannot find a module with name %s when looking at imports in %s", i.Name, e.Path()))
+				return nil
+			}
+
+			pfxMap[i.Prefix.Name] = m.Prefix.Name
 		}
 
 		if prefix, _ := getPrefix(parts[0]); prefix != "" {
@@ -845,6 +855,7 @@ func (e *Entry) Find(name string) *Entry {
 				// This is an undefined prefix within our context, so
 				// we can't do anything about resolving it.
 				e.addError(fmt.Errorf("invalid module prefix %s within module %s, defined prefix map: %v", prefix, e.Name, pfxMap))
+				return nil
 			}
 			m, err := e.Modules().FindModuleByPrefix(pfx)
 			if err != nil {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -212,6 +212,22 @@ module baz {
 }
 `,
 	},
+	{
+		name: "baz-augment.yang",
+		in: `
+		submodule baz-augment {
+		  belongs-to baz {
+		    prefix "baz";
+		  }
+
+		  import foo { prefix "f"; }
+
+		  augment "/f:foo-c" {
+		    leaf baz-submod-leaf { type string; }
+		  }
+		}
+		`,
+	},
 }
 
 func TestUsesParent(t *testing.T) {
@@ -353,11 +369,11 @@ func TestIgnoreCircularDependencies(t *testing.T) {
 				}
 			`,
 			"subm-y": `
-        submodule subm-y {
-          belongs-to mod-a { prefix a; }
-          // Not circular.
-          include subm-x;
-        }
+			submodule subm-y {
+				belongs-to mod-a { prefix a; }
+				// Not circular.
+				include subm-x;
+			}
       `},
 	}, {
 		name: "circular dependency error identified",
@@ -561,46 +577,46 @@ func TestFullModuleProcess(t *testing.T) {
 		name: "circular import via child",
 		inModules: map[string]string{
 			"test": `
-      module test {
-      	prefix "t";
-      	namespace "urn:t";
+			      module test {
+				      	prefix "t";
+					namespace "urn:t";
 
-      	include test-router;
-      	include test-router-bgp;
-      	include test-router-isis;
+				      	include test-router;
+				   	include test-router-bgp;
+				      	include test-router-isis;
 
-      	container configure {
-      		uses test-router;
-      	}
-      }`,
+				   	container configure {
+						uses test-router;
+					}
+				}`,
 			"test-router": `
-      submodule test-router {
-      	belongs-to test { prefix "t"; }
+				submodule test-router {
+					belongs-to test { prefix "t"; }
 
-      	include test-router-bgp;
-      	include test-router-isis;
-      	include test-router-ldp;
+					include test-router-bgp;
+					include test-router-isis;
+					include test-router-ldp;
 
-      	grouping test-router {
-      		uses test-router-ldp;
-      	}
-      }`,
+					grouping test-router {
+						uses test-router-ldp;
+					}
+				}`,
 			"test-router-ldp": `
-      submodule test-router-ldp {
-      	belongs-to test { prefix "t"; }
+				submodule test-router-ldp {
+					belongs-to test { prefix "t"; }
 
-      	grouping test-router-ldp { }
-      }`,
+					grouping test-router-ldp { }
+				}`,
 			"test-router-isis": `
-      submodule test-router-isis {
-      	belongs-to test { prefix "t"; }
+				 submodule test-router-isis {
+					belongs-to test { prefix "t"; }
 
-      	include test-router;
-      }`,
+					include test-router;
+				}`,
 			"test-router-bgp": `
-      submodule test-router-bgp {
-      	belongs-to test { prefix "t"; }
-      }`,
+				submodule test-router-bgp {
+					belongs-to test { prefix "t"; }
+				}`,
 		},
 		inIgnoreCircDeps: true,
 	}, {


### PR DESCRIPTION
```
 * (M) pkg/yang/entry.go
   - Previously, when an augment existed within a submodule, then Find()
     was called, and this caused a panic because the submodule's Prefix
     statement was nil. This CL fixes the Find() function to be aware of
     submodules.
   - Resolve an issue whereby Module for an Node might be nil, if it
     has not yet been processed fully, such as when processing augments.
  * (M) pkg/yang/entry_test.go
   - Add a test case which previously paniced to demonstrate fix.
```