### PR TITLE
yang: Fix Find() to retrieve rpc/action Entry

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -647,7 +647,9 @@ func ToEntry(n Node) (e *Entry) {
 				if e.RPC == nil {
 					e.RPC = &RPCEntry{}
 				}
-				e.RPC.Input = ToEntry(i)
+				in := ToEntry(i)
+				in.Parent = e
+				e.RPC.Input = in
 				e.RPC.Input.Name = "input"
 				e.RPC.Input.Kind = InputEntry
 			}
@@ -656,7 +658,9 @@ func ToEntry(n Node) (e *Entry) {
 				if e.RPC == nil {
 					e.RPC = &RPCEntry{}
 				}
-				e.RPC.Output = ToEntry(o)
+				out := ToEntry(o)
+				out.Parent = e
+				e.RPC.Output = out
 				e.RPC.Output.Name = "output"
 				e.RPC.Output.Kind = OutputEntry
 			}
@@ -875,6 +879,13 @@ func (e *Entry) Find(name string) *Entry {
 		case part == ".":
 		case part == "..":
 			e = e.Parent
+		case e.RPC != nil:
+			switch part {
+			case "input":
+				e = e.RPC.Input
+			case "output":
+				e = e.RPC.Output
+			}
 		default:
 			_, part = getPrefix(part)
 			switch part {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1127,6 +1127,19 @@ func TestEntryFind(t *testing.T) {
 					leaf b { type string; }
 
 					container c { leaf d { type string; } }
+
+                    rpc rpc1 {
+                        input { leaf input1 { type string; } }
+                    }
+
+                    container e {
+                        action operation {
+                          description "action";
+                          input { leaf input1 { type string; } }
+                          output { leaf output1 { type string; } }
+                        }
+                    }
+
 				}
 			`,
 		},
@@ -1149,8 +1162,12 @@ func TestEntryFind(t *testing.T) {
 			"../t:c/d":   "/test/c/d",
 			"../c/t:d":   "/test/c/d",
 			// Find within an absolute directory with prefixes.
-			"/t:c/d": "/test/c/d",
-			"/c/t:d": "/test/c/d",
+			"/t:c/d":                "/test/c/d",
+			"/c/t:d":                "/test/c/d",
+			"../t:rpc1/input":       "/test/rpc1/input",
+			"/t:rpc1/input":         "/test/rpc1/input",
+			"/t:e/operation/input":  "/test/e/operation/input",
+			"/t:e/operation/output": "/test/e/operation/output",
 		},
 	}, {
 		name: "inter-module find",
@@ -1240,7 +1257,7 @@ func TestEntryFind(t *testing.T) {
 		for path, want := range tt.wantEntryPath {
 			got := dir[tt.inBaseEntryPath].Find(path)
 			if got.Path() != want {
-				t.Errorf("%s: (entry %s).Find(%s), did not find path, got: %v, want: %v, errors: %v", tt.name, dir[tt.inBaseEntryPath].Path(), path, got, want, dir[tt.inBaseEntryPath].Errors)
+				t.Errorf("%s: (entry %s).Find(%s), did not find path, got: %v, want: %v, errors: %v", tt.name, dir[tt.inBaseEntryPath].Path(), path, got.Path(), want, dir[tt.inBaseEntryPath].Errors)
 			}
 		}
 	}


### PR DESCRIPTION
Goyang does not successfully `(*yang.Entry).Find()` valid absolute-schema-node-identifier used in
IETF standard YANG modules, e.g.,

  `/nc:get-config/nc:input`

Such as in the `ietf-netconf-time@2016-01-26.yang` module,
where "nc" refers to ietf-netconf. This is a valid YANG
`absolute-schema-node-identifier` referring to the NETCONF
`get-config` RPC definition's input container, which holds
the argument envelopes for the RPC.

Find was not finding these; while it validated the prefix and
traversed "ietf-netconf" module root to the "get-config" schema node
entry, it did not find "input", because the "input" and "output" path
elements are not inserted into the (*yang.Entry).Dir map.

Also link from the Input and Output entries to the parent (action or
RPC) entry so Path() works, among other things.

Add tests which will fail without the associated patches.