### PR TITLE
Remove special string handling for patterns in double-quotes.

### DIFF
--- a/pkg/yang/lex.go
+++ b/pkg/yang/lex.go
@@ -457,11 +457,6 @@ func lexQString(l *lexer) stateFn {
 				c = '\t'
 			case '"':
 			case '\\':
-				if l.inPattern {
-					// We are parsing a pattern, so
-					// leave \\ as \\.
-					text = append(text, '\\')
-				}
 			default:
 				// Strings are use both in descriptions and
 				// in patterns.  In strings only \n, \t, \"

--- a/pkg/yang/parse_test.go
+++ b/pkg/yang/parse_test.go
@@ -105,7 +105,7 @@ foo "\\ \S \n";
 pattern "\\ \S \n";
 `,
 			out: []*Statement{
-				SA("pattern", `\\ \S 
+				SA("pattern", `\ \S
 `),
 			},
 		},

--- a/pkg/yang/parse_test.go
+++ b/pkg/yang/parse_test.go
@@ -105,7 +105,7 @@ foo "\\ \S \n";
 pattern "\\ \S \n";
 `,
 			out: []*Statement{
-				SA("pattern", `\ \S
+				SA("pattern", `\ \S 
 `),
 			},
 		},


### PR DESCRIPTION
```
  * (M) pkg/yang/lex.go
    - The lexer previously gave special handling to \\ in a
      YANG pattern-stmt, per #73 this appears to be against the
      spec, and \\ in a pattern should be handled as per any
      other double quoted string (i.e., as \).
  * (M) pkg/yang/parse_test.go
    - Ensure that parser is updated to consider the above change.
```