### PR TITLE
Add SequenceNum to Entries for Ordering

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -79,6 +79,9 @@ type Entry struct {
 	// Fields associated with directory nodes
 	Dir map[string]*Entry `json:",omitempty"`
 	Key string            `json:",omitempty"` // Optional key name for lists (i.e., maps)
+	// SequenceNum indicates order of the entry relative to the parent
+	// from the original yang module
+	SequenceNum int64     `json:",omitempty"`
 
 	// Fields associated with leaf nodes
 	Type *YangType    `json:",omitempty"`
@@ -352,6 +355,7 @@ func (e *Entry) add(key string, value *Entry) *Entry {
 		return e
 	}
 	e.Dir[key] = value
+	value.SequenceNum = int64(len(e.Dir))
 	return e
 }
 


### PR DESCRIPTION
Currently ordering from the original yang module is lost when parsing the module as the children in entries are added to a map.
* This adds a SequenceNum field to the Entry struct that represents the original ordering from the yang module
(pending tests)