### PR TITLE
Resolve duplicate deviation processing with non-nil revision stmt.

### DIFF
--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -385,11 +385,15 @@ func (ms *Modules) Process() []error {
 	// rather we can just walk all modules and submodules *after* entries
 	// are resolved. This means we do not need to concern ourselves that
 	// an entry does not exist.
-	for _, m := range ms.Modules {
-		errs = append(errs, ToEntry(m).ApplyDeviate()...)
-	}
-	for _, m := range ms.SubModules {
-		errs = append(errs, ToEntry(m).ApplyDeviate()...)
+	dvP := map[string]bool{} // cache the modules we've handled since we have both modname and modname@revision-date
+	for _, devmods := range []map[string]*Module{ms.Modules, ms.SubModules} {
+		for _, m := range devmods {
+			e := ToEntry(m)
+			if !dvP[e.Name] {
+				errs = append(errs, e.ApplyDeviate()...)
+				dvP[e.Name] = true
+			}
+		}
 	}
 
 	return errorSort(errs)


### PR DESCRIPTION
This PR resolves an issue whereby if a module specified a revision
statement and contained deviations then the deviations would be
processed for both modname and modname@revision such that not-supported
deviations then could not be found.