### PR TITLE
Augment-ed *Entry and Use'd *Entry stored in parent *Entry's new Augmented and Uses fields.

### DIFF
--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -129,6 +129,61 @@ func TestMarshalJSON(t *testing.T) {
 					},
 				},
 			},
+			Augments: []*Entry{{
+				Name: "augment",
+				Node: &Leaf{
+					Name: "leaf",
+				},
+				Kind:   LeafEntry,
+				Config: TSFalse,
+				Prefix: &Value{
+					Name: "ModulePrefix",
+					Source: &Statement{
+						Keyword:     "prefix",
+						Argument:    "ModulePrefix",
+						HasArgument: true,
+					},
+				},
+			}},
+			Augmented: []*Entry{{
+				Name: "augmented",
+				Node: &Leaf{
+					Name: "leaf",
+				},
+				Kind:   LeafEntry,
+				Config: TSTrue,
+				Prefix: &Value{
+					Name: "ModulePrefix",
+					Source: &Statement{
+						Keyword:     "prefix",
+						Argument:    "ModulePrefix",
+						HasArgument: true,
+					},
+				},
+			}},
+			Uses: []*UsesStmt{{
+				Uses: &Uses{
+					Name: "grouping",
+				},
+				Grouping: &Entry{
+					Name: "grouping",
+					Node: &Grouping{
+						Name: "grouping",
+						Leaf: []*Leaf{{
+							Name: "groupingLeaf",
+						}},
+					},
+					Config: TSFalse,
+					Prefix: &Value{
+						Name: "ModulePrefix",
+						Source: &Statement{
+							Keyword:     "prefix",
+							Argument:    "ModulePrefix",
+							HasArgument: true,
+						},
+					},
+				},
+			}},
 		},
 		want: `{
   "Name": "container",
@@ -183,7 +238,57 @@ func TestMarshalJSON(t *testing.T) {
         ]
       }
     }
-  }
+  },
+  "Augments": [
+    {
+      "Name": "augment",
+      "Kind": 0,
+      "Config": 2,
+      "Prefix": {
+        "Name": "ModulePrefix",
+        "Source": {
+          "Keyword": "prefix",
+          "HasArgument": true,
+          "Argument": "ModulePrefix"
+        }
+      }
+    }
+  ],
+  "Augmented": [
+    {
+      "Name": "augmented",
+      "Kind": 0,
+      "Config": 1,
+      "Prefix": {
+        "Name": "ModulePrefix",
+        "Source": {
+          "Keyword": "prefix",
+          "HasArgument": true,
+          "Argument": "ModulePrefix"
+        }
+      }
+    }
+  ],
+  "Uses": [
+    {
+      "Uses": {
+        "Name": "grouping"
+      },
+      "Grouping": {
+        "Name": "grouping",
+        "Kind": 0,
+        "Config": 2,
+        "Prefix": {
+          "Name": "ModulePrefix",
+          "Source": {
+            "Keyword": "prefix",
+            "HasArgument": true,
+            "Argument": "ModulePrefix"
+          }
+        }
+      }
+    }
+  ]
 }`,
 	}, {
 		name: "Entry with list and leaflist",

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -622,17 +622,17 @@ func (s *Grouping) Typedefs() []*Typedef   { return s.Typedef }
 // A Uses is defined in: http://tools.ietf.org/html/rfc6020#section-7.12
 type Uses struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:"-"`
 
-	Augment     *Augment  `yang:"augment"`
-	Description *Value    `yang:"description"`
-	IfFeature   []*Value  `yang:"if-feature"`
-	Refine      []*Refine `yang:"refine"`
-	Reference   *Value    `yang:"reference"`
-	Status      *Value    `yang:"status"`
-	When        *Value    `yang:"when"`
+	Augment     *Augment  `yang:"augment" json:",omitempty"`
+	Description *Value    `yang:"description" json:",omitempty"`
+	IfFeature   []*Value  `yang:"if-feature" json:"-"`
+	Refine      []*Refine `yang:"refine" json:"-"`
+	Reference   *Value    `yang:"reference" json:"-"`
+	Status      *Value    `yang:"status" json:"-"`
+	When        *Value    `yang:"when" json:",omitempty"`
 }
 
 func (Uses) Kind() string             { return "uses" }


### PR DESCRIPTION
This perserves the Augment *Entry and Uses *Entry so their when statements can be enforced, among other things.

This is my attempt at fixing issue #89 