### PR TITLE
Add support for description and reference in import block.

### DIFF
--- a/pkg/yang/file_test.go
+++ b/pkg/yang/file_test.go
@@ -96,9 +96,9 @@ func TestScanForPathsAndAddModules(t *testing.T) {
 	// add the paths found in the scan to the module path
 	AddPath(paths...)
 
-	// confirm we can load the four modules that exist in
+	// confirm we can load the five modules that exist in
 	// the two paths we scanned.
-	modules := []string{"aug", "base", "other", "subdir1"}
+	modules := []string{"aug", "base", "other", "subdir1", "import"}
 	ms := NewModules()
 	for _, name := range modules {
 		if _, err := ms.GetModule(name); err != nil {

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -212,6 +212,8 @@ type Import struct {
 
 	Prefix       *Value `yang:"prefix,required"`
 	RevisionDate *Value `yang:"revision-date"`
+	Reference    *Value `yang:"reference,nomerge"`
+	Description  *Value `yang:"description,nomerge"`
 
 	// Module is the imported module.  The types and groupings are
 	// available to the importer with the defined prefix.

--- a/testdata/import.yang
+++ b/testdata/import.yang
@@ -1,0 +1,15 @@
+// Copyright 2019 Arista Inc.
+
+module import {
+  namespace "urn:mod";
+  prefix "import";
+
+  import base {
+    prefix base;
+    description "description in import block";
+  }
+  import other {
+    prefix other;
+    reference "RFC xyz refers to other";
+  }
+}


### PR DESCRIPTION
We require this one for the new Yang models: yang-schema-mount and yang-network-instance

based on Yang 1.1