### PR TITLE
Check for dot when converting identifier to camel case

### DIFF
--- a/pkg/yang/camelcase.go
+++ b/pkg/yang/camelcase.go
@@ -31,15 +31,15 @@ func isASCIIDigit(c byte) bool {
 // CamelCase returns a CamelCased name for a YANG identifier.
 // Currently this supports the output being used for a Go or proto identifier.
 // Dash and dot are first converted to underscore, and then any underscores
-// before a lower-case letter are removed, and the letter converted to upper-case.
+// before a lower-case letter are removed, and the letter converted to
+// upper-case. Any input characters not part of the YANG identifier
+// specification (https://tools.ietf.org/html/rfc7950#section-6.2) are treated
+// as lower-case characters.
 // The first letter is always upper-case in order to be an exported name in Go.
 // There is a remote possibility of this rewrite causing a name collision, but
 // it's so remote we're prepared to pretend it's nonexistent - since the C++
 // generator lowercases names, it's extremely unlikely to have two fields with
 // different capitalizations. In short, _my_field-name_2 becomes XMyFieldName_2.
-// If the input does not conform to the YANG identifier specification
-// (https://tools.ietf.org/html/rfc7950#section-6.2), then there is no
-// guarantee on the form of the output.
 func CamelCase(s string) string {
 	if s == "" {
 		return ""

--- a/pkg/yang/camelcase_test.go
+++ b/pkg/yang/camelcase_test.go
@@ -24,15 +24,19 @@ func TestCamelCase(t *testing.T) {
 	}{
 		{"one", "One"},
 		{"one_two", "OneTwo"},
+		{"__one__two__three__four", "XOne_Two_Three_Four"},
+		{"one.two.three", "OneTwoThree"},
+		{"one.two.three.", "OneTwoThree_"},
 		{"_my_field_name_2", "XMyFieldName_2"},
 		{"Something_Capped", "Something_Capped"},
-		{"/foo/bar", "XFooBar"},
+		{"_Foo-bar", "XFooBar"},
 		{"my_Name", "My_Name"},
 		{"OneTwo", "OneTwo"},
 		{"_", "X"},
 		{"_a_", "XA_"},
 		{"ietf-interface", "IETFInterface"},
 		{"ietf-interface-1", "IETFInterface_1"},
+		{"out-unicast.pkts", "OutUnicastPkts"},
 	}
 	for _, tc := range tests {
 		if got := CamelCase(tc.in); got != tc.want {

--- a/pkg/yang/camelcase_test.go
+++ b/pkg/yang/camelcase_test.go
@@ -37,6 +37,13 @@ func TestCamelCase(t *testing.T) {
 		{"ietf-interface", "IETFInterface"},
 		{"ietf-interface-1", "IETFInterface_1"},
 		{"out-unicast.pkts", "OutUnicastPkts"},
+		// Invalid input conversion behaviours:
+		{"one/two", "One/two"},
+		{"/one/two", "/one/two"},
+		{"one:two", "One:two"},
+		{"::one::two", "::one::two"},
+		{"one|two", "One|two"},
+		{"one||two", "One||two"},
 	}
 	for _, tc := range tests {
 		if got := CamelCase(tc.in); got != tc.want {


### PR DESCRIPTION
See https://github.com/openconfig/ygot/issues/333

I went through each use in ygot and this function is only used for converting from YANG identifiers to Go or proto identifiers, so I'm modifying the function comment to make that clear.

Aside from not converting from ":" or "/" anymore, and converting from "." now, there is no other functional change. While it is possible to return an error for invalid inputs, I feel it makes the error handling burdensome for the callers, so I decided to keep the function insecure from invalid input.