### PR TITLE
Do not drop extensions when merging a grouping Entry

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1316,9 +1316,11 @@ func (e *Entry) merge(prefix *Value, namespace *Value, oe *Entry) {
 			e.addError(er.Errors[0])
 		} else {
 			v.Parent = e
+			v.Exts = append(v.Exts, oe.Exts...)
 			e.Dir[k] = v
 		}
 	}
+
 }
 
 // nless returns -1 if a is less than b, 0 if a == b, and 1 if a > b.

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1320,7 +1320,6 @@ func (e *Entry) merge(prefix *Value, namespace *Value, oe *Entry) {
 			e.Dir[k] = v
 		}
 	}
-
 }
 
 // nless returns -1 if a is less than b, 0 if a == b, and 1 if a > b.

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1313,17 +1313,17 @@ func TestFullModuleProcess(t *testing.T) {
 				}
 
 				container c {
-					ext:a-define "hello";
+					ext:c-define "c's extension";
 					uses daughter-group {
-						ext:d-define "universe";
+						ext:u-define "uses's extension";
 					}
 				}
 
 				grouping daughter-group {
-					ext:b-define "world";
+					ext:g-define "grouping's extension";
 
 					leaf l {
-						ext:c-define "at large";
+						ext:l-define "l's extension";
 						type string;
 					}
 
@@ -1340,28 +1340,28 @@ func TestFullModuleProcess(t *testing.T) {
 				prefix "q";
 				namespace "urn:q";
 
-				extension a-define {
-					description
-					"Takes as an argument a name string.
-					Acquire something.";
-					argument "name";
-			       }
-				extension b-define {
-					description
-					"Takes as an argument a name string.
-					Be something.";
-					argument "name";
-			       }
 				extension c-define {
 					description
 					"Takes as an argument a name string.
-					Create something.";
+					c's extension.";
 					argument "name";
 			       }
-				extension d-define {
+				extension g-define {
 					description
 					"Takes as an argument a name string.
-					Derive something.";
+					grouping's extension.";
+					argument "name";
+			       }
+				extension l-define {
+					description
+					"Takes as an argument a name string.
+					l's extension.";
+					argument "name";
+			       }
+				extension u-define {
+					description
+					"Takes as an argument a name string.
+					uses's extension.";
 					argument "name";
 			       }
 			}
@@ -1378,24 +1378,24 @@ func TestFullModuleProcess(t *testing.T) {
 			less := cmpopts.SortSlices(func(l, r *Statement) bool { return l.Keyword < r.Keyword })
 
 			wantExts := []*Statement{
-				{Keyword: "ext:a-define", HasArgument: true, Argument: "hello"},
+				{Keyword: "ext:c-define", HasArgument: true, Argument: "c's extension"},
 			}
 			if diff := cmp.Diff(wantExts, module.Dir["c"].Exts, cmpopts.IgnoreUnexported(Statement{}), less); diff != "" {
 				t.Errorf("container c Exts (-want, +got):\n%s", diff)
 			}
 
 			wantExts = []*Statement{
-				{Keyword: "ext:b-define", HasArgument: true, Argument: "world"},
-				{Keyword: "ext:c-define", HasArgument: true, Argument: "at large"},
-				{Keyword: "ext:d-define", HasArgument: true, Argument: "universe"},
+				{Keyword: "ext:g-define", HasArgument: true, Argument: "grouping's extension"},
+				{Keyword: "ext:l-define", HasArgument: true, Argument: "l's extension"},
+				{Keyword: "ext:u-define", HasArgument: true, Argument: "uses's extension"},
 			}
 			if diff := cmp.Diff(wantExts, module.Dir["c"].Dir["l"].Exts, cmpopts.IgnoreUnexported(Statement{}), less); diff != "" {
 				t.Errorf("leaf l Exts (-want, +got):\n%s", diff)
 			}
 
 			wantExts = []*Statement{
-				{Keyword: "ext:b-define", HasArgument: true, Argument: "world"},
-				{Keyword: "ext:d-define", HasArgument: true, Argument: "universe"},
+				{Keyword: "ext:g-define", HasArgument: true, Argument: "grouping's extension"},
+				{Keyword: "ext:u-define", HasArgument: true, Argument: "uses's extension"},
 			}
 			if diff := cmp.Diff(wantExts, module.Dir["c"].Dir["c2"].Exts, cmpopts.IgnoreUnexported(Statement{}), less); diff != "" {
 				t.Errorf("container c2 Exts (-want, +got):\n%s", diff)


### PR DESCRIPTION
Currently, when the `merge` function carries out the transplant of top-level nodes from a grouping to their target parent, extensions at the grouping level, which are stored at a temporary Entry to which the top-level nodes are attached before transplanting, are being dropped. This is because the `merge` code forgets about the `Exts` field when it carries out the transplant operation.

This change simply transplants the extensions as well to all the top-level nodes to make the transplant more complete.

See example #108 

Fixes #108 