### PR TITLE
Prune pkg/yang

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -430,8 +430,6 @@ var entryCache = map[Node]*Entry{}
 // the name of the including (sub)module and the included submodule.
 var mergedSubmodule = map[string]bool{}
 
-var depth = 0
-
 // deviationType specifies an enumerated value covering the different substmts
 // to the deviate statement.
 type deviationType int64

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -352,12 +352,6 @@ func (e *Entry) GetErrors() []error {
 	return errorSort(errs)
 }
 
-// asKind sets the kind of e to k and returns e.
-func (e *Entry) asKind(k EntryKind) *Entry {
-	e.Kind = k
-	return e
-}
-
 // add adds the directory entry key assigned to the provided value.
 func (e *Entry) add(key string, value *Entry) *Entry {
 	value.Parent = e


### PR DESCRIPTION
This removes the unused `depth` variable as well as the unused function `Entry.asKind()` from `pkg/yang`.