### PR TITLE
Add short optional format to optional arguments

### DIFF
--- a/yang.go
+++ b/yang.go
@@ -92,11 +92,11 @@ func main() {
 	var traceP string
 	var help bool
 	var paths []string
-	getopt.ListVarLong(&paths, "path", 0, "comma separated list of directories to add to search path", "DIR[,DIR...]")
-	getopt.StringVarLong(&format, "format", 0, "format to display: "+strings.Join(formats, ", "), "FORMAT")
-	getopt.StringVarLong(&traceP, "trace", 0, "write trace into to TRACEFILE", "TRACEFILE")
-	getopt.BoolVarLong(&help, "help", '?', "display help")
-	getopt.BoolVarLong(&yang.ParseOptions.IgnoreSubmoduleCircularDependencies, "ignore-circdep", 0, "ignore circular dependencies between submodules")
+	getopt.ListVarLong(&paths, "path", 'p', "comma separated list of directories to add to search path", "DIR[,DIR...]")
+	getopt.StringVarLong(&format, "format", 'f', "format to display: "+strings.Join(formats, ", "), "FORMAT")
+	getopt.StringVarLong(&traceP, "trace", 't', "write trace into to TRACEFILE", "TRACEFILE")
+	getopt.BoolVarLong(&help, "help", 'h', "display help")
+	getopt.BoolVarLong(&yang.ParseOptions.IgnoreSubmoduleCircularDependencies, "ignore-circdep", 'g', "ignore circular dependencies between submodules")
 	getopt.SetParameters("[FORMAT OPTIONS] [SOURCE] [...]")
 
 	if err := getopt.Getopt(func(o getopt.Option) bool {


### PR DESCRIPTION
I find that the optional arguments for goyang may have short formats.

Such as `"--format"` can be both `"--format"` and `"-f"`
