### PR TITLE
Move sort from YangRang Validate to parseRanges

### DIFF
--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -859,6 +859,7 @@ func parseRanges(s string, decimal bool, fracDigRequired uint8) (YangRange, erro
 		}
 		r[i] = YRange{min, max}
 	}
+	sort.Sort(r)
 	if err := r.Validate(); err != nil {
 		return nil, err
 	}
@@ -944,10 +945,9 @@ func (r YangRange) Less(i, j int) bool {
 	}
 }
 
-// Validate sorts r and returns an error if r has either an invalid range or has
+// Validate returns an error if r has either an invalid range or has
 // overlapping ranges.
 func (r YangRange) Validate() error {
-	sort.Sort(r)
 	switch {
 	case len(r) == 0:
 		return nil

--- a/pkg/yang/types_builtin_test.go
+++ b/pkg/yang/types_builtin_test.go
@@ -305,6 +305,28 @@ func TestCoalesce(t *testing.T) {
 	}
 }
 
+func TestYangRangeSort(t *testing.T) {
+	for x, tt := range []struct {
+                in, out YangRange
+        }{
+                {YangRange{}, YangRange{}},
+                {YangRange{R(1, 4), R(6, 10)}, YangRange{R(1, 4), R(6, 10)}},
+                {YangRange{R(6, 10), R(1, 4)}, YangRange{R(1, 4), R(6, 10)}},
+                {YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}, YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}},
+                {YangRange{Rf(30, 40, 1), Rf(10, 25, 1)}, YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}},
+                {YangRange{R(1, 2)}, YangRange{R(1, 2)}},
+                {YangRange{R(1, 2), R(4, 5)}, YangRange{R(1, 2), R(4, 5)}},
+                {YangRange{R(1, 3), R(2, 5)}, YangRange{R(1, 3), R(2, 5)}},
+                {YangRange{R(1, 10), R(2, 5)}, YangRange{R(1, 10), R(2, 5)}},
+                {YangRange{R(1, 10), R(1, 2), R(4, 5), R(7, 8)}, YangRange{R(1, 2), R(1, 10), R(4, 5), R(7, 8)}},
+        } {
+                tt.in.Sort()
+                if !tt.in.Equal(tt.out) {
+                        t.Errorf("#%d: got %v, want %v", x, tt.in, tt.out)
+                }
+        }
+}
+
 func TestParseRangesDecimal(t *testing.T) {
 	tests := []struct {
 		desc             string

--- a/pkg/yang/types_builtin_test.go
+++ b/pkg/yang/types_builtin_test.go
@@ -307,24 +307,24 @@ func TestCoalesce(t *testing.T) {
 
 func TestYangRangeSort(t *testing.T) {
 	for x, tt := range []struct {
-                in, out YangRange
-        }{
-                {YangRange{}, YangRange{}},
-                {YangRange{R(1, 4), R(6, 10)}, YangRange{R(1, 4), R(6, 10)}},
-                {YangRange{R(6, 10), R(1, 4)}, YangRange{R(1, 4), R(6, 10)}},
-                {YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}, YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}},
-                {YangRange{Rf(30, 40, 1), Rf(10, 25, 1)}, YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}},
-                {YangRange{R(1, 2)}, YangRange{R(1, 2)}},
-                {YangRange{R(1, 2), R(4, 5)}, YangRange{R(1, 2), R(4, 5)}},
-                {YangRange{R(1, 3), R(2, 5)}, YangRange{R(1, 3), R(2, 5)}},
-                {YangRange{R(1, 10), R(2, 5)}, YangRange{R(1, 10), R(2, 5)}},
-                {YangRange{R(1, 10), R(1, 2), R(4, 5), R(7, 8)}, YangRange{R(1, 2), R(1, 10), R(4, 5), R(7, 8)}},
-        } {
-                tt.in.Sort()
-                if !tt.in.Equal(tt.out) {
-                        t.Errorf("#%d: got %v, want %v", x, tt.in, tt.out)
-                }
-        }
+		in, out YangRange
+	}{
+		{YangRange{}, YangRange{}},
+		{YangRange{R(1, 4), R(6, 10)}, YangRange{R(1, 4), R(6, 10)}},
+		{YangRange{R(6, 10), R(1, 4)}, YangRange{R(1, 4), R(6, 10)}},
+		{YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}, YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}},
+		{YangRange{Rf(30, 40, 1), Rf(10, 25, 1)}, YangRange{Rf(10, 25, 1), Rf(30, 40, 1)}},
+		{YangRange{R(1, 2)}, YangRange{R(1, 2)}},
+		{YangRange{R(1, 2), R(4, 5)}, YangRange{R(1, 2), R(4, 5)}},
+		{YangRange{R(1, 3), R(2, 5)}, YangRange{R(1, 3), R(2, 5)}},
+		{YangRange{R(1, 10), R(2, 5)}, YangRange{R(1, 10), R(2, 5)}},
+		{YangRange{R(1, 10), R(1, 2), R(4, 5), R(7, 8)}, YangRange{R(1, 2), R(1, 10), R(4, 5), R(7, 8)}},
+	} {
+		tt.in.Sort()
+		if !tt.in.Equal(tt.out) {
+			t.Errorf("#%d: got %v, want %v", x, tt.in, tt.out)
+		}
+	}
 }
 
 func TestParseRangesDecimal(t *testing.T) {


### PR DESCRIPTION
Validate is also called from ygot/ytypes/int_type.go to validate YangRange. This creates race conditions.