### PR TITLE
Add Support for posix-pattern Extension within YangType

### DIFF
--- a/pkg/yang/node.go
+++ b/pkg/yang/node.go
@@ -124,6 +124,21 @@ func FindModuleByPrefix(n Node, prefix string) *Module {
 	return nil
 }
 
+func MatchingExtensions(n Node, module, identifier string) ([]*Statement, error) {
+	var matchingExtensions []*Statement
+	for _, ext := range n.Exts() {
+		names := strings.SplitN(ext.Keyword, ":", 2)
+		mod := FindModuleByPrefix(n, names[0])
+		if mod == nil {
+			return nil, fmt.Errorf("MatchingExtensions: module %s not found", module)
+		}
+		if len(names) == 2 && names[1] == identifier && mod.Name == module {
+			matchingExtensions = append(matchingExtensions, ext)
+		}
+	}
+	return matchingExtensions, nil
+}
+
 // RootNode returns the submodule or module that n was defined in.
 func RootNode(n Node) *Module {
 	for ; n.ParentNode() != nil; n = n.ParentNode() {

--- a/pkg/yang/node.go
+++ b/pkg/yang/node.go
@@ -132,7 +132,7 @@ func MatchingExtensions(n Node, module, identifier string) ([]*Statement, error)
 		names := strings.SplitN(ext.Keyword, ":", 2)
 		mod := FindModuleByPrefix(n, names[0])
 		if mod == nil {
-			return nil, fmt.Errorf("MatchingExtensions: module %s not found", module)
+			return nil, fmt.Errorf("MatchingExtensions: module prefix %q not found", names[0])
 		}
 		if len(names) == 2 && names[1] == identifier && mod.Name == module {
 			matchingExtensions = append(matchingExtensions, ext)

--- a/pkg/yang/node.go
+++ b/pkg/yang/node.go
@@ -124,6 +124,8 @@ func FindModuleByPrefix(n Node, prefix string) *Module {
 	return nil
 }
 
+// MatchingExtensions returns the subset of the given node's extensions
+// that match the given module and identifier.
 func MatchingExtensions(n Node, module, identifier string) ([]*Statement, error) {
 	var matchingExtensions []*Statement
 	for _, ext := range n.Exts() {

--- a/pkg/yang/node_test.go
+++ b/pkg/yang/node_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/gnmi/errdiff"
 )
 
 func TestNodePath(t *testing.T) {
@@ -69,10 +70,11 @@ func TestNodePath(t *testing.T) {
 // the YANG library.
 func TestNode(t *testing.T) {
 	tests := []struct {
-		desc      string
-		inFn      func(*Modules) (Node, error)
-		inModules map[string]string
-		wantNode  func(Node) error
+		desc          string
+		inFn          func(*Modules) (Node, error)
+		inModules     map[string]string
+		wantNode      func(Node) error
+		wantErrSubstr string
 	}{{
 		desc: "import reference statement",
 		inFn: func(ms *Modules) (Node, error) {
@@ -202,13 +204,118 @@ func TestNode(t *testing.T) {
 						description "foo module";
 					}
 
+					import foo2 {
+						prefix "f2";
+						description "foo2 module";
+					}
+
 					leaf test-leaf {
 						type string {
 							pattern 'alpha';
+							// Test different modules and different ext names.
 							f:bar 'boo';
+							f2:bar 'boo2';
+
 							f:bar 'coo';
-							f:far 'coo';
+							f2:bar 'coo2';
+
+							f:far 'doo';
+							f2:far 'doo2';
+
 							f:bar 'foo';
+							f2:bar 'foo2';
+
+							f:far 'goo';
+							f2:far 'goo2';
+						}
+					}
+				}
+			`,
+			"foo": `
+				module foo {
+					prefix "f";
+					namespace "urn:f";
+
+					extension bar {
+						argument "baz";
+					}
+
+					extension far {
+						argument "baz";
+					}
+				}
+			`,
+			"foo2": `
+				module foo2 {
+					prefix "f2";
+					namespace "urn:f2";
+
+					extension bar {
+						argument "baz";
+					}
+
+					extension far {
+						argument "baz";
+					}
+				}
+			`,
+		},
+		wantNode: func(n Node) error {
+			n, ok := n.(*Type)
+			if !ok {
+				return fmt.Errorf("got node: %v, want type: Leaf", n)
+			}
+
+			var bars []string
+			matches, err := MatchingExtensions(n, "foo", "bar")
+			if err != nil {
+				return err
+			}
+			for _, ext := range matches {
+				bars = append(bars, ext.Argument)
+			}
+
+			if diff := cmp.Diff(bars, []string{"boo", "coo", "foo"}); diff != "" {
+				return fmt.Errorf("MatchingExtensions (-got, +want):\n%s", diff)
+			}
+
+			return nil
+		},
+	}, {
+		desc: "Test MatchingExtensions when module is not found",
+		inFn: func(ms *Modules) (Node, error) {
+
+			m, err := ms.FindModuleByPrefix("t")
+			if err != nil {
+				return nil, fmt.Errorf("can't find module in %v", ms)
+			}
+
+			if len(m.Leaf) == 0 {
+				return nil, fmt.Errorf("node %v is missing imports", m)
+			}
+
+			_, err = ms.FindModuleByPrefix("f")
+			if err != nil {
+				return nil, err
+			}
+
+			return m.Leaf[0].Type, nil
+		},
+		inModules: map[string]string{
+			"test": `
+				module test {
+					prefix "t";
+					namespace "urn:t";
+
+					import foo {
+						prefix "f";
+						description "foo module";
+					}
+
+					leaf test-leaf {
+						type string {
+							pattern 'alpha';
+							not-found:bar 'foo';
 						}
 					}
 				}
@@ -249,6 +356,7 @@ func TestNode(t *testing.T) {
 
 			return nil
 		},
+		wantErrSubstr: `module prefix "not-found" not found`,
 	}}
 
 	for _, tt := range tests {
@@ -261,8 +369,18 @@ func TestNode(t *testing.T) {
 				}
 			}
 
-			if errs := ms.Process(); errs != nil {
-				t.Fatal(errs)
+			errs := ms.Process()
+			var err error
+			if len(errs) > 1 {
+				t.Fatalf("Got more than 1 error: %v", errs)
+			} else if len(errs) == 1 {
+				err = errs[0]
+			}
+			if diff := errdiff.Substring(err, tt.wantErrSubstr); diff != "" {
+				t.Errorf("Did not get expected error: %s", diff)
+			}
+			if err != nil {
+				return
 			}
 
 			node, err := tt.inFn(ms)

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -24,8 +24,9 @@ import (
 )
 
 // UsePosixPatternExt specifies that openconfig-extensions:posix-pattern should
-// be used in place of the default pattern statement for all string types.
-// If the extension is not found, then the parsing will fail.
+// be used in place of the default pattern statement for all string types.  If
+// the number of posix-pattern statements doesn't match the number of pattern
+// statements within each type statement, the parsing will fail.
 var UsePosixPatternExt bool
 
 // A typeDictionary is a dictonary of all Typedefs defined in all Typedefers.
@@ -372,6 +373,7 @@ check:
 	}
 
 	if UsePosixPatternExt {
+		// Use posix pattern extension in place of the existing patterns.
 		posixPatterns, err := MatchingExtensions(t, "openconfig-extensions", "posix-pattern")
 		if err != nil {
 			return []error{err}

--- a/pkg/yang/types_builtin.go
+++ b/pkg/yang/types_builtin.go
@@ -285,6 +285,7 @@ type YangType struct {
 	OptionalInstance bool        `json:",omitempty"` // !require-instances which defaults to true
 	Path             string      `json:",omitempty"` // the path in a leafref
 	Pattern          []string    `json:",omitempty"` // limiting XSD-TYPES expressions on strings
+	POSIXPattern     []string    `json:",omitempty"` // limiting POSIX ERE on strings (specified by openconfig-extensions:posix-pattern)
 	Range            YangRange   `json:",omitempty"` // range for integers
 	Type             []*YangType `json:",omitempty"` // for unions
 }

--- a/pkg/yang/types_test.go
+++ b/pkg/yang/types_test.go
@@ -318,6 +318,31 @@ func TestPattern(t *testing.T) {
 		},
 		wantPatternsRegular: []string{"alpha", "bravo", "charlie"},
 		wantPatternsPOSIX:   []string{"delta", "echo", "foxtrot"},
+	}, {
+		desc: "invalid POSIX pattern",
+		leafNode: `
+			leaf test-leaf {
+				type leaf-type;
+			}
+
+			typedef leaf-type {
+				type string {
+					o:posix-pattern '?';
+				}
+			}
+		} // end module`,
+		inGetFn: func(ms *Modules) (*YangType, error) {
+			m, err := ms.FindModuleByPrefix("t")
+			if err != nil {
+				return nil, fmt.Errorf("can't find module in %v", ms)
+			}
+			if len(m.Leaf) == 0 {
+				return nil, fmt.Errorf("node %v is missing imports", m)
+			}
+			e := ToEntry(m)
+			return e.Dir["test-leaf"].Type, nil
+		},
+		wantErrSubstr: "bad pattern",
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Added global variable `UsePosixPatternExt` to allow a `posix-pattern` extension from `openconfig-extensions.yang` to be used to replace pattern statements. This variable must be flipped prior to using goyang for consistent behaviour.

Restriction when `UsePosixPatternExt` is set:
- The number of `posix-pattern` statements must match the number of `pattern` statements within each type statement. Otherwise `goyang` parsing will fail.