### PR TITLE
Correctly inherit fraction-digit in typedef decimal64

### DIFF
--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -2808,7 +2808,7 @@ func TestLeafEntryTypes(t *testing.T) {
 			}
 			`,
 		},
-		wantErrSubstr: "fraction-digits not allowed in this base type",
+		wantErrSubstr: "overriding of fraction-digits not allowed",
 	}}
 
 	for _, tt := range tests {

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -239,8 +239,10 @@ check:
 	}
 	// If we are directly of type decimal64 then we must specify
 	// fraction-digits.
-	isDecimal64 := y.Kind == Ydecimal64 && (t.Name == "decimal64" || t.FractionDigits != nil)
+	isDecimal64 := y.Kind == Ydecimal64 && (t.Name == "decimal64" || y.FractionDigits != 0)
 	switch {
+	case isDecimal64 && y.FractionDigits != 0:
+		// FractionDigits already set via type inheritance.
 	case isDecimal64:
 		i, err := t.FractionDigits.asRangeInt(1, 18)
 		if err != nil {

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -241,7 +241,7 @@ check:
 	switch {
 	case isDecimal64 && y.FractionDigits != 0:
 		if t.FractionDigits != nil {
-			return append(errs, fmt.Errorf("%s: fraction-digits not allowed in this base type", Source(t)))
+			return append(errs, fmt.Errorf("%s: overriding of fraction-digits not allowed", Source(t)))
 		}
 		// FractionDigits already set via type inheritance.
 	case isDecimal64:

--- a/pkg/yang/types.go
+++ b/pkg/yang/types.go
@@ -237,13 +237,16 @@ check:
 	if v := t.Path; v != nil {
 		y.Path = v.asString()
 	}
-	// If we are directly of type decimal64 then we must specify
-	// fraction-digits.
 	isDecimal64 := y.Kind == Ydecimal64 && (t.Name == "decimal64" || y.FractionDigits != 0)
 	switch {
 	case isDecimal64 && y.FractionDigits != 0:
+		if t.FractionDigits != nil {
+			return append(errs, fmt.Errorf("%s: fraction-digits not allowed in this base type", Source(t)))
+		}
 		// FractionDigits already set via type inheritance.
 	case isDecimal64:
+		// If we are directly of type decimal64 then we must specify
+		// fraction-digits in the range from 1-18.
 		i, err := t.FractionDigits.asRangeInt(1, 18)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %v", Source(t), err))


### PR DESCRIPTION
Currently, whether a `decimal64` is a typedef is not detected if `t.FractionDigits` is unset in the typedef. So the ranges are being parsed as integer ranges, leading to https://github.com/openconfig/ygot/issues/397.

This change correctly identifies typedefs, and inherits the `FractionDigits` field correctly -- by not doing anything.

Note on the 3rd test case: whether overriding of `fraction-digits` is allowed is not specifically mentioned in the RFC. I followed `pyang`'s behaviour of erroring out if overriding is detected.