### PR TITLE
Add support for multiple `base` substatements in `identity` statement

### DIFF
--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -168,18 +168,20 @@ func (ms *Modules) resolveIdentities() []error {
 	// that have a base, so that we can do inheritance of these later.
 	for _, i := range identities.dict {
 		if i.Identity.Base != nil {
-			// This identity inherits from another identity.
+			// This identity inherits from one or more other identities.
 
 			root := RootNode(i.Identity)
-			base, baseErr := root.findIdentityBase(i.Identity.Base.asString())
+			for _, b := range i.Identity.Base {
+				base, baseErr := root.findIdentityBase(b.asString())
 
-			if baseErr != nil {
-				errs = append(errs, baseErr...)
-				continue
+				if baseErr != nil {
+					errs = append(errs, baseErr...)
+					continue
+				}
+
+				// Append this value to the children of the base identity.
+				base.Identity.Values = append(base.Identity.Values, i.Identity)
 			}
-
-			// Append this value to the children of the base identity.
-			base.Identity.Values = append(base.Identity.Values, i.Identity)
 		}
 	}
 

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -128,14 +128,14 @@ func TestIdentityExtract(t *testing.T) {
 			}
 
 			if ti.baseName != "" {
-				if ti.baseName != thisID.Base.Name {
+				if ti.baseName != thisID.Base[0].Name {
 					t.Errorf("Identity %s did not have expected base %s, had %s", ti.name,
-						ti.baseName, thisID.Base.Name)
+						ti.baseName, thisID.Base[0].Name)
 				}
 			} else {
 				if thisID.Base != nil {
 					t.Errorf("Identity %s had an unexpected base %s", thisID.Name,
-						thisID.Base.Name)
+						thisID.Base[0].Name)
 				}
 			}
 		}
@@ -439,9 +439,9 @@ func TestIdentityTree(t *testing.T) {
 			}
 
 			if chkID.baseName != "" {
-				if chkID.baseName != foundID.Base.Name {
+				if chkID.baseName != foundID.Base[0].Name {
 					t.Errorf("Couldn't find base %s for ID %s", chkID.baseName,
-						foundID.Base.Name)
+						foundID.Base[0].Name)
 				}
 			}
 

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -818,7 +818,7 @@ type Identity struct {
 	Parent     Node         `yang:"Parent,nomerge" json:"-"`
 	Extensions []*Statement `yang:"Ext" json:"-"`
 
-	Base        *Value      `yang:"base" json:"-"`
+	Base        []*Value    `yang:"base" json:"-"`
 	Description *Value      `yang:"description" json:"-"`
 	IfFeature   []*Value    `yang:"if-feature" json:"-"`
 	Reference   *Value      `yang:"reference" json:"-"`


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7950#section-7.18, there can be multiple `base` substatements in an `identity` statement in YANG 1.1.

This PR changes the type of `Base` to be a slice and loops over all `base` statements in `identity`.