### PR TITLE
Add support for multiple `base` substatements in `identity` statement

### DIFF
--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -168,18 +168,20 @@ func (ms *Modules) resolveIdentities() []error {
 	// that have a base, so that we can do inheritance of these later.
 	for _, i := range identities.dict {
 		if i.Identity.Base != nil {
-			// This identity inherits from another identity.
+			// This identity inherits from one or more other identities.
 
 			root := RootNode(i.Identity)
-			base, baseErr := root.findIdentityBase(i.Identity.Base.asString())
+			for _, b := range i.Identity.Base {
+				base, baseErr := root.findIdentityBase(b.asString())
 
-			if baseErr != nil {
-				errs = append(errs, baseErr...)
-				continue
+				if baseErr != nil {
+					errs = append(errs, baseErr...)
+					continue
+				}
+
+				// Append this value to the children of the base identity.
+				base.Identity.Values = append(base.Identity.Values, i.Identity)
 			}
-
-			// Append this value to the children of the base identity.
-			base.Identity.Values = append(base.Identity.Values, i.Identity)
 		}
 	}
 

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -128,14 +128,14 @@ func TestIdentityExtract(t *testing.T) {
 			}
 
 			if ti.baseName != "" {
-				if ti.baseName != thisID.Base.Name {
+				if ti.baseName != thisID.Base[0].Name {
 					t.Errorf("Identity %s did not have expected base %s, had %s", ti.name,
-						ti.baseName, thisID.Base.Name)
+						ti.baseName, thisID.Base[0].Name)
 				}
 			} else {
 				if thisID.Base != nil {
 					t.Errorf("Identity %s had an unexpected base %s", thisID.Name,
-						thisID.Base.Name)
+						thisID.Base[0].Name)
 				}
 			}
 		}
@@ -439,9 +439,9 @@ func TestIdentityTree(t *testing.T) {
 			}
 
 			if chkID.baseName != "" {
-				if chkID.baseName != foundID.Base.Name {
+				if chkID.baseName != foundID.Base[0].Name {
 					t.Errorf("Couldn't find base %s for ID %s", chkID.baseName,
-						foundID.Base.Name)
+						foundID.Base[0].Name)
 				}
 			}
 

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -17,6 +17,8 @@ package yang
 import (
 	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // inputModule is a mock input YANG module.
@@ -35,8 +37,7 @@ type idrefOut struct {
 type identityOut struct {
 	module    string   // The module that the identity is within.
 	name      string   // The name of the identity.
-	baseName  string   // The base of the identity as a string.
-	baseNames []string // The bases of the identity in test cases with multiple bases
+	baseNames []string // The base(s) of the identity as string(s).
 	values    []string // The string names of derived identities.
 }
 
@@ -47,6 +48,15 @@ type identityTestCase struct {
 	identities []identityOut // Slice of the identity values expected
 	idrefs     []idrefOut    // Slice of identityref results expected
 	err        string        // Test case error string
+}
+
+// getBaseNamesFrom is a utility function for getting the base name(s) of an identity
+func getBaseNamesFrom(i *Identity) []string {
+	baseNames := []string{}
+	for _, base := range i.Base {
+		baseNames = append(baseNames, base.Name)
+	}
+	return baseNames
 }
 
 // Test cases for basic identity extraction.
@@ -91,7 +101,7 @@ var basicTestCases = []identityTestCase{
 		identities: []identityOut{
 			{module: "idtest-two", name: "TEST_ID"},
 			{module: "idtest-two", name: "TEST_ID_TWO"},
-			{module: "idtest-two", name: "TEST_CHILD", baseName: "TEST_ID"},
+			{module: "idtest-two", name: "TEST_CHILD", baseNames: []string{"TEST_ID"}},
 		},
 		err: "basic-test-case-2: could not resolve identities",
 	},
@@ -154,24 +164,15 @@ func TestIdentityExtract(t *testing.T) {
 				t.Errorf("Could not found identity %s in %s", ti.name, ti.module)
 			}
 
-			if ti.baseName != "" {
-				if ti.baseName != thisID.Base[0].Name {
-					t.Errorf("Identity %s did not have expected base %s, had %s", ti.name,
-						ti.baseName, thisID.Base[0].Name)
-				}
-			} else if len(ti.baseNames) >= 1 {
-				actualBaseNames := []string{}
-				for _, base := range thisID.Base {
-					actualBaseNames = append(actualBaseNames, base.Name)
-				}
-				if !reflect.DeepEqual(ti.baseNames, actualBaseNames) {
-					t.Errorf("Identity %s did not have expected base %s, had %s", ti.name,
-						ti.baseNames, actualBaseNames)
+			actualBaseNames := getBaseNamesFrom(thisID)
+			if len(ti.baseNames) > 0 {
+				if diff := cmp.Diff(actualBaseNames, ti.baseNames); diff != "" {
+					t.Errorf("(-got, +want):\n%s", diff)
 				}
 			} else {
 				if thisID.Base != nil {
-					t.Errorf("Identity %s had an unexpected base %s", thisID.Name,
-						thisID.Base[0].Name)
+					t.Errorf("Identity %s had unexpected base(s) %s", thisID.Name,
+						actualBaseNames)
 				}
 			}
 		}
@@ -215,9 +216,9 @@ var treeTestCases = []identityTestCase{
 				values: []string{"LOCAL_REMOTE_BASE"},
 			},
 			{
-				module:   "base",
-				name:     "LOCAL_REMOTE_BASE",
-				baseName: "r:REMOTE_BASE",
+				module:    "base",
+				name:      "LOCAL_REMOTE_BASE",
+				baseNames: []string{"r:REMOTE_BASE"},
 			},
 		},
 	},
@@ -267,31 +268,31 @@ var treeTestCases = []identityTestCase{
 				},
 			},
 			{
-				module:   "base",
-				name:     "GRANDFATHER",
-				baseName: "GREATGRANDFATHER",
-				values:   []string{"FATHER", "UNCLE", "SON", "BROTHER"},
+				module:    "base",
+				name:      "GRANDFATHER",
+				baseNames: []string{"GREATGRANDFATHER"},
+				values:    []string{"FATHER", "UNCLE", "SON", "BROTHER"},
 			},
 			{
-				module:   "base",
-				name:     "GREATUNCLE",
-				baseName: "GREATGRANDFATHER",
+				module:    "base",
+				name:      "GREATUNCLE",
+				baseNames: []string{"GREATGRANDFATHER"},
 			},
 			{
-				module:   "base",
-				name:     "FATHER",
-				baseName: "GRANDFATHER",
-				values:   []string{"SON", "BROTHER"},
+				module:    "base",
+				name:      "FATHER",
+				baseNames: []string{"GRANDFATHER"},
+				values:    []string{"SON", "BROTHER"},
 			},
 			{
-				module:   "base",
-				name:     "UNCLE",
-				baseName: "GRANDFATHER",
+				module:    "base",
+				name:      "UNCLE",
+				baseNames: []string{"GRANDFATHER"},
 			},
 			{
-				module:   "base",
-				name:     "BROTHER",
-				baseName: "FATHER",
+				module:    "base",
+				name:      "BROTHER",
+				baseNames: []string{"FATHER"},
 			},
 		},
 	},
@@ -324,9 +325,9 @@ var treeTestCases = []identityTestCase{
 				values: []string{"NOTBASE"},
 			},
 			{
-				module:   "base",
-				name:     "NOTBASE",
-				baseName: "BASE",
+				module:    "base",
+				name:      "NOTBASE",
+				baseNames: []string{"BASE"},
 			},
 		},
 		idrefs: []idrefOut{
@@ -370,9 +371,9 @@ var treeTestCases = []identityTestCase{
 				values: []string{"CHILD4"},
 			},
 			{
-				module:   "base4",
-				name:     "CHILD4",
-				baseName: "BASE4",
+				module:    "base4",
+				name:      "CHILD4",
+				baseNames: []string{"BASE4"},
 			},
 		},
 		idrefs: []idrefOut{
@@ -474,10 +475,10 @@ func TestIdentityTree(t *testing.T) {
 					chkID.module)
 			}
 
-			if chkID.baseName != "" {
-				if chkID.baseName != foundID.Base[0].Name {
-					t.Errorf("Couldn't find base %s for ID %s", chkID.baseName,
-						foundID.Base[0].Name)
+			if len(chkID.baseNames) > 0 {
+				actualBaseNames := getBaseNamesFrom(foundID)
+				if diff := cmp.Diff(actualBaseNames, chkID.baseNames); diff != "" {
+					t.Errorf("(-got, +want):\n%s", diff)
 				}
 			}
 

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -818,7 +818,7 @@ type Identity struct {
 	Parent     Node         `yang:"Parent,nomerge" json:"-"`
 	Extensions []*Statement `yang:"Ext" json:"-"`
 
-	Base        *Value      `yang:"base" json:"-"`
+	Base        []*Value    `yang:"base" json:"-"`
 	Description *Value      `yang:"description" json:"-"`
 	IfFeature   []*Value    `yang:"if-feature" json:"-"`
 	Reference   *Value      `yang:"reference" json:"-"`


### PR DESCRIPTION
Squashed commit of the following:

commit 2cd89ac3d2344838867d446393e6e5174dca7700
Author: Herman Slatman <hermanslatman@hotmail.com>
Date:   Mon Jun 29 00:20:41 2020 +0200

    Fix existing tests that assume a single `base`

commit 528bac09ed575c111335a5d6b3589a5ab4e5c456
Author: Herman Slatman <hermanslatman@hotmail.com>
Date:   Mon Jun 29 00:14:23 2020 +0200

    Change `base` to be a slice

commit d1f5ccb6c756769739f92618e3a6149819a5526e
Author: Herman Slatman <hermanslatman@hotmail.com>
Date:   Mon Jun 29 00:08:06 2020 +0200

    Add support for multiple `base` substatements in `identity` statement