### PR TITLE
removed unnecessary type conversion

### DIFF
--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -50,7 +50,7 @@ func (ms *Modules) Read(name string) error {
 	if err != nil {
 		return err
 	}
-	return ms.Parse(string(data), name)
+	return ms.Parse(data, name)
 }
 
 // Parse parses data as YANG source and adds it to ms.  The name should reflect


### PR DESCRIPTION
It seems to me its safe to remove the type conversion in that case since the `data` is [already](https://github.com/openconfig/goyang/blob/b6e1e28273ad274f9240361b3a1ae65d27c045ac/pkg/yang/file.go#L91) a `string`.