### PR TITLE
fix findFile to search for revisioned modules for all paths

### DIFF
--- a/pkg/yang/file.go
+++ b/pkg/yang/file.go
@@ -112,7 +112,7 @@ func findFile(name string) (string, string, error) {
 		if filepath.Base(dir) == "..." {
 			n = scanDir(filepath.Dir(dir), name, true)
 		} else {
-			n = filepath.Join(dir, name)
+			n = scanDir(dir, name, false)
 		}
 		if n == "" {
 			continue


### PR DESCRIPTION
@wenovus, as we discussed in #138, this PR adds the missing functionality.
I did not add any comment to the `findFile()` func, since its looks correct to me. 

closes #138