### PR TITLE
Detect missing closing brace from input

### DIFF
--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -331,22 +331,20 @@ func (p *parser) nextStatement() *Statement {
 // Checks that we have a statement depth of 0. It's an error to exit
 // the parser with a depth of > 0, it means we are missing closing
 // braces. Note: the parser will error out for the case where we
-// start with an unmatched close brace
+// start with an unmatched close brace, eg. depth < 0
 //
 // This test is only done if there are no other errors as
 // we may exit early due to those errors -- and therefore there *might*
 // not really be a mismatched brace issue.
 func (p *parser) checkStatementDepth() {
-	// don't check if there are other errors
-	if p.errout.Len() > 0 {
+	if p.errout.Len() > 0 || p.statementDepth < 1 {
 		return
 	}
-	if p.statementDepth > 0 {
-		plural := ""
-		if p.statementDepth > 1 {
-			plural = "s"
-		}
-		fmt.Fprintf(p.errout, "%s:%d:%d: missing %d closing brace%s\n",
-			p.lex.file, p.lex.line, p.lex.col, p.statementDepth, plural)
+
+	plural := ""
+	if p.statementDepth > 1 {
+		plural = "s"
 	}
+	fmt.Fprintf(p.errout, "%s:%d:%d: missing %d closing brace%s\n",
+		p.lex.file, p.lex.line, p.lex.col, p.statementDepth, plural)
 }

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -35,6 +35,7 @@ type parser struct {
 	errout *bytes.Buffer
 	tokens []*token // stack of pushed tokens (for backing up)
 
+	// Depth of statements in nested braces
 	statementDepth int
 
 	// hitBrace is returned when we encounter a '}'.  The statement location

--- a/pkg/yang/parse_test.go
+++ b/pkg/yang/parse_test.go
@@ -269,6 +269,25 @@ test.yang:9:9: invalid escape sequence: \3
 test.yang:9:9: missing closing "
 test.yang: unexpected EOF`,
 		},
+		{line: line(), in: `
+module base {
+   container top-missing-close-brace {
+      leaf my-leaf {
+        type string;
+      }
+   }
+`,
+			err: "test.yang:8:0: missing 1 closing brace",
+		},
+		{line: line(), in: `
+module base {
+   container top-missing-close-brace {
+      leaf my-leaf {
+        type string;
+   }
+`,
+			err: "test.yang:7:0: missing 2 closing braces",
+		},
 	} {
 		s, err := Parse(tt.in, "test.yang")
 		if (s == nil) != (tt.out == nil) {


### PR DESCRIPTION
Consider the case of the following yang that is missing the final
closing brace for ```module foo```

```
module foo {
  namespace foo;
  prefix f;

  container top {
     leaf f1 {
        type string;
     }
  }

```

parsing that with ```./goyang -f tree test.yang``` results in no error
and no output.

With this patch we output an error that says we are missing a closing
brace.