### PR TITLE
Add NewListAttr() function to construct ListAttr with MaxElements=math.MaxUint64

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -142,7 +142,9 @@ type ListAttr struct {
 	OrderedBy   *Value // order of entries determined by "system" or "user"
 }
 
-func NewListAttr() *ListAttr {
+// NewDefaultListAttr returns a new ListAttr object with min/max elements being
+// set to 0/math.MaxUint64 respectively.
+func NewDefaultListAttr() *ListAttr {
 	return &ListAttr{
 		MinElements: 0,
 		MaxElements: math.MaxUint64,
@@ -603,7 +605,7 @@ func ToEntry(n Node) (e *Entry) {
 		}
 
 		e := ToEntry(leaf)
-		e.ListAttr = NewListAttr()
+		e.ListAttr = NewDefaultListAttr()
 		e.ListAttr.OrderedBy = s.OrderedBy
 		var err error
 		if e.ListAttr.MaxElements, err = semCheckMaxElements(s.MaxElements); err != nil {
@@ -636,7 +638,7 @@ func ToEntry(n Node) (e *Entry) {
 	// Nodes of identified special kinds have their Kind set here.
 	switch s := n.(type) {
 	case *List:
-		e.ListAttr = NewListAttr()
+		e.ListAttr = NewDefaultListAttr()
 		e.ListAttr.OrderedBy = s.OrderedBy
 		var err error
 		if e.ListAttr.MaxElements, err = semCheckMaxElements(s.MaxElements); err != nil {
@@ -930,7 +932,7 @@ func ToEntry(n Node) (e *Entry) {
 			}
 
 			if e.ListAttr == nil {
-				e.ListAttr = NewListAttr()
+				e.ListAttr = NewDefaultListAttr()
 			}
 
 			// Only record the deviation if the statement exists.

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -142,6 +142,13 @@ type ListAttr struct {
 	OrderedBy   *Value // order of entries determined by "system" or "user"
 }
 
+func NewListAttr() *ListAttr {
+	return &ListAttr{
+		MinElements: 0,
+		MaxElements: math.MaxUint64,
+	}
+}
+
 // A UsesStmt associates a *Uses with its referenced grouping *Entry
 type UsesStmt struct {
 	Uses     *Uses
@@ -596,9 +603,8 @@ func ToEntry(n Node) (e *Entry) {
 		}
 
 		e := ToEntry(leaf)
-		e.ListAttr = &ListAttr{
-			OrderedBy: s.OrderedBy,
-		}
+		e.ListAttr = NewListAttr()
+		e.ListAttr.OrderedBy = s.OrderedBy
 		var err error
 		if e.ListAttr.MaxElements, err = semCheckMaxElements(s.MaxElements); err != nil {
 			e.addError(err)
@@ -630,9 +636,8 @@ func ToEntry(n Node) (e *Entry) {
 	// Nodes of identified special kinds have their Kind set here.
 	switch s := n.(type) {
 	case *List:
-		e.ListAttr = &ListAttr{
-			OrderedBy: s.OrderedBy,
-		}
+		e.ListAttr = NewListAttr()
+		e.ListAttr.OrderedBy = s.OrderedBy
 		var err error
 		if e.ListAttr.MaxElements, err = semCheckMaxElements(s.MaxElements); err != nil {
 			e.addError(err)
@@ -925,7 +930,7 @@ func ToEntry(n Node) (e *Entry) {
 			}
 
 			if e.ListAttr == nil {
-				e.ListAttr = &ListAttr{}
+				e.ListAttr = NewListAttr()
 			}
 
 			// Only record the deviation if the statement exists.


### PR DESCRIPTION
users of goyang can also make use of this call (e.g. ygot).

Having this function helps with test writing.