### PR TITLE
Bugfix #151: Remove the redundant 'union' in the tree type output

### DIFF
--- a/types.go
+++ b/types.go
@@ -112,7 +112,7 @@ func printType(w io.Writer, t *yang.YangType, verbose bool) {
 		fmt.Fprintf(w, " range=%s", t.Range)
 	}
 	if len(t.Type) > 0 {
-		fmt.Fprintf(w, "union{\n")
+		fmt.Fprintf(w, "{\n")
 		for _, t := range t.Type {
 			printType(indent.NewWriter(w, "  "), t, verbose)
 		}


### PR DESCRIPTION
Hi @wenovus Wenbo,
Currently goyang will print double "union" in the output with `-f type` option.
This PR remove the redundant "union" in the output.