### PR TITLE
Clean-up Parser and Lexer

### DIFF
--- a/pkg/yang/lex.go
+++ b/pkg/yang/lex.go
@@ -20,7 +20,7 @@ package yang
 //    tError       // an error was encountered
 //    tEOF         // end-of-file
 //    tString      // A de-quoted string (e.g., "\"bob\"" becomes "bob")
-//    tIdentifier  // An un-quoted string
+//    tUnquoted    // An un-quoted string
 //    '{'
 //    ';'
 //    '}'
@@ -40,9 +40,6 @@ const (
 	eof       = 0x7fffffff // end of file, also an invalid rune
 	maxErrors = 8
 	tooMany   = "too many errors...\n"
-
-	openBrace  = '{'
-	closeBrace = '}'
 )
 
 // stateFn represents a state in the lexer as a function, returning the next
@@ -76,10 +73,10 @@ type lexer struct {
 type code int
 
 const (
-	tEOF        = code(-1 - iota) // Reached end of file
-	tError                        // An error
-	tString                       // A dequoted string
-	tIdentifier                   // A non-quoted string
+	tEOF      = code(-1 - iota) // Reached end of file
+	tError                      // An error
+	tString                     // A dequoted string
+	tUnquoted                   // A non-quoted string
 )
 
 // String returns c as a string.
@@ -89,8 +86,8 @@ func (c code) String() string {
 		return "Error"
 	case tString:
 		return "String"
-	case tIdentifier:
-		return "Identifier"
+	case tUnquoted:
+		return "Unquoted"
 	}
 	if c < 0 || c > '~' {
 		return fmt.Sprintf("%d", c)
@@ -358,7 +355,7 @@ func lexGround(l *lexer) stateFn {
 	switch c := l.peek(); c {
 	case eof:
 		return nil
-	case ';', openBrace, closeBrace:
+	case ';', '{', '}':
 		l.next()
 		l.emit(code(c))
 		return lexGround
@@ -400,7 +397,7 @@ func lexGround(l *lexer) stateFn {
 		}
 		fallthrough
 	default:
-		return lexIdentifier
+		return lexUnquoted
 	}
 }
 
@@ -486,21 +483,21 @@ func lexQString(l *lexer) stateFn {
 	}
 }
 
-// lexIdentifier reads one identifier/number/un-quoted-string/...
+// lexUnquoted reads one identifier/number/un-quoted-string/...
 //
 // From https://tools.ietf.org/html/rfc7950#section-6.1.3:
 // An unquoted string is any sequence of characters that does not
 // contain any space, tab, carriage return, or line feed characters, a
 // single or double quote character, a semicolon (";"), braces ("{" or
 // "}"), or comment sequences ("//", "/*", or "*/").
-func lexIdentifier(l *lexer) stateFn {
+func lexUnquoted(l *lexer) stateFn {
 	for {
 		switch c := l.peek(); c {
 		// TODO: Support detection of comment immediately following an
-		// identifier, likely through supporting two peeks instead of
-		// just one.
-		case ' ', '\r', '\n', '\t', ';', '"', '\'', openBrace, closeBrace, eof:
-			l.emit(tIdentifier)
+		// unquoted string, likely through supporting two peeks instead
+		// of just one.
+		case ' ', '\r', '\n', '\t', ';', '"', '\'', '{', '}', eof:
+			l.emit(tUnquoted)
 			return lexGround
 		default:
 			l.next()

--- a/pkg/yang/lex_test.go
+++ b/pkg/yang/lex_test.go
@@ -46,64 +46,64 @@ Tests:
 	}{
 		{line(), "", nil},
 		{line(), "bob", []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 		}},
 		{line(), "bob //bob", []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 		}},
 		{line(), "/the/path", []*token{
-			T(tIdentifier, "/the/path"),
+			T(tUnquoted, "/the/path"),
 		}},
 		{line(), "+the/path", []*token{
-			T(tIdentifier, "+the/path"),
+			T(tUnquoted, "+the/path"),
 		}},
 		{line(), "+the+path", []*token{
-			T(tIdentifier, "+the+path"),
+			T(tUnquoted, "+the+path"),
 		}},
 		{line(), "+ the/path", []*token{
-			T(tIdentifier, "+"),
-			T(tIdentifier, "the/path"),
+			T(tUnquoted, "+"),
+			T(tUnquoted, "the/path"),
 		}},
 		{line(), "{bob}", []*token{
 			T('{', "{"),
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T('}', "}"),
 		}},
 		{line(), "bob;fred", []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), "\t bob\t; fred ", []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), `
 	bob;
 	fred
 `, []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), `
 	// This is a comment
 	bob;
 	fred
 `, []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), `
 	/* This is a comment */
 	bob;
 	fred
 `, []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), `
 	/*
@@ -112,17 +112,17 @@ Tests:
 	bob;
 	fred
 `, []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), `
 	bob; // This is bob
 	fred // This is fred
 `, []*token{
-			T(tIdentifier, "bob"),
+			T(tUnquoted, "bob"),
 			T(';', ";"),
-			T(tIdentifier, "fred"),
+			T(tUnquoted, "fred"),
 		}},
 		{line(), `
 // tab indent both lines

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -151,8 +151,8 @@ func (s *Statement) Write(w io.Writer, indent string) error {
 	return nil
 }
 
-// ignoreMe is an error recovery terminal used by the parser in
-// order to continue processing for other errors in the file.
+// ignoreMe is an error recovery non-terminal token used by the parser in order
+// to continue processing for other errors in the file.
 var ignoreMe = &Statement{}
 
 // Parse parses the input as generic YANG and returns the statements parsed.

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -17,9 +17,6 @@ package yang
 // This file implements Parse, which  parses the input as generic YANG and
 // returns a slice of base Statements (which in turn may contain more
 // Statements, i.e., a slice of Statement trees.)
-//
-// TODO(borman): remove this TODO once ast.go is part of of this package.
-// See ast.go for the conversion of Statements into an AST tree of Nodes.
 
 import (
 	"bytes"
@@ -47,8 +44,13 @@ type parser struct {
 	hitBrace *Statement
 }
 
-// A Statement is a generic YANG statement.  A Statement may have optional
-// sub-statement (i.e., a Statement is a tree).
+// Statement is a generic YANG statement that may have sub-statements.
+// It implements the Node interface.
+//
+// Within the parser, it represents a non-terminal token.
+// From https://tools.ietf.org/html/rfc7950#section-6.3:
+// statement = keyword [argument] (";" / "{" *statement "}")
+// The argument is a string.
 type Statement struct {
 	Keyword     string
 	HasArgument bool
@@ -60,16 +62,6 @@ type Statement struct {
 	col  int // 1's based column number
 }
 
-// FakeStatement returns a statement filled in with keyword, file, line and col.
-func FakeStatement(keyword, file string, line, col int) *Statement {
-	return &Statement{
-		Keyword: keyword,
-		file:    file,
-		line:    line,
-		col:     col,
-	}
-}
-
 func (s *Statement) NName() string         { return s.Argument }
 func (s *Statement) Kind() string          { return s.Keyword }
 func (s *Statement) Statement() *Statement { return s }
@@ -79,9 +71,6 @@ func (s *Statement) Exts() []*Statement    { return nil }
 // Arg returns the optional argument to s.  It returns false if s has no
 // argument.
 func (s *Statement) Arg() (string, bool) { return s.Argument, s.HasArgument }
-
-// Keyword returns the keyword of s.
-//func (s *Statement) Keyword() string { return s.Keyword }
 
 // SubStatements returns a slice of Statements found in s.
 func (s *Statement) SubStatements() []*Statement { return s.statements }
@@ -162,8 +151,8 @@ func (s *Statement) Write(w io.Writer, indent string) error {
 	return nil
 }
 
-// ignoreMe is returned to continue processing after an error (the parse will
-// fail, but we want to look for more errors).
+// ignoreMe is an error recovery non-terminal used by the parser in
+// order to continue processing for other errors in the file.
 var ignoreMe = &Statement{}
 
 // Parse parses the input as generic YANG and returns the statements parsed.
@@ -185,19 +174,18 @@ Loop:
 		case nil:
 			break Loop
 		case p.hitBrace:
-			fmt.Fprintf(p.errout, "%s:%d:%d: unexpected %c\n", ns.file, ns.line, ns.col, closeBrace)
+			fmt.Fprintf(p.errout, "%s:%d:%d: unexpected %c\n", ns.file, ns.line, ns.col, '}')
 		default:
 			statements = append(statements, ns)
 		}
 	}
 
-	p.checkStatementDepth()
+	p.checkStatementDepthIsZero()
 
 	if p.errout.Len() == 0 {
 		return statements, nil
 	}
 	return nil, errors.New(strings.TrimSpace(p.errout.String()))
-
 }
 
 // push pushes tokens t back on the input stream so they will be the next
@@ -217,12 +205,13 @@ func (p *parser) pop() *token {
 	return nil
 }
 
-// next returns the next token from the lexer.  It also handles string
-// concatenation.
+// next returns the next token from the lexer. If the next token is a
+// concatenated string, it returns the concatenated string as the token.
 func (p *parser) next() *token {
 	if t := p.pop(); t != nil {
 		return t
 	}
+	// next returns the next unprocessed lexer token.
 	next := func() *token {
 		for {
 			if t := p.lex.NextToken(); t.Code() != tError {
@@ -234,13 +223,15 @@ func (p *parser) next() *token {
 	if t.Code() != tString {
 		return t
 	}
-	// Handle `"string" + "string"`
+	// Process string concatenation (both single and double quote).
+	// See https://tools.ietf.org/html/rfc7950#section-6.1.3.1
+	// The lexer trimmed the quotes already.
 	for {
 		nt := next()
 		switch nt.Code() {
 		case tEOF:
 			return t
-		case tIdentifier:
+		case tUnquoted:
 			if nt.Text != "+" {
 				p.push(nt)
 				return t
@@ -249,42 +240,44 @@ func (p *parser) next() *token {
 			p.push(nt)
 			return t
 		}
-		// We found a +, now look for a following string
-		st := next()
-		switch st.Code() {
+		// Invariant: nt is a + sign.
+		nnt := next()
+		switch nnt.Code() {
 		case tEOF:
 			p.push(nt)
 			return t
 		case tString:
-			// concatenate the text and drop the nt and st tokens
-			// try again
-			t.Text += st.Text
+			// Accumulate the concatenation.
+			t.Text += nnt.Text
 		default:
-			p.push(st, nt)
+			p.push(nnt, nt)
 			return t
 		}
-
 	}
 }
 
 // nextStatement returns the next statement in the input, which may in turn
 // recurse to read sub statements.
+// nil is returned when EOF has been reached, or is reached halfway through
+// parsing the next statement (with associated syntax errors printed to
+// errout).
 func (p *parser) nextStatement() *Statement {
 	t := p.next()
 	switch t.Code() {
 	case tEOF:
 		return nil
-	case closeBrace:
+	case '}':
 		p.statementDepth -= 1
 		p.hitBrace.file = t.File
 		p.hitBrace.line = t.Line
 		p.hitBrace.col = t.Col
 		return p.hitBrace
-	case tIdentifier:
+	case tUnquoted:
 	default:
-		fmt.Fprintf(p.errout, "%v: not an identifier\n", t)
+		fmt.Fprintf(p.errout, "%v: keyword token not an unquoted string\n", t)
 		return ignoreMe
 	}
+	// Invariant: t represents a keyword token.
 
 	s := &Statement{
 		Keyword: t.Text,
@@ -293,29 +286,31 @@ func (p *parser) nextStatement() *Statement {
 		col:     t.Col,
 	}
 
-	// The keyword "pattern" must be treated special.  When
+	// The keyword "pattern" must be treated specially. When
 	// parsing the argument for "pattern", escape sequences
 	// must be expanded differently.
 	p.lex.inPattern = t.Text == "pattern"
 	t = p.next()
 	p.lex.inPattern = false
 	switch t.Code() {
-	case tString, tIdentifier:
+	case tString, tUnquoted:
 		s.HasArgument = true
 		s.Argument = t.Text
 		t = p.next()
 	}
+
 	switch t.Code() {
 	case tEOF:
 		fmt.Fprintf(p.errout, "%s: unexpected EOF\n", s.file)
 		return nil
 	case ';':
 		return s
-	case openBrace:
+	case '{':
 		p.statementDepth += 1
 		for {
 			switch ns := p.nextStatement(); ns {
 			case nil:
+				// Signal EOF reached.
 				return nil
 			case p.hitBrace:
 				return s
@@ -324,21 +319,20 @@ func (p *parser) nextStatement() *Statement {
 			}
 		}
 	default:
-		fmt.Fprintf(p.errout, "%v: syntax error\n", t)
+		fmt.Fprintf(p.errout, "%v: syntax error, expected ';' or nested statements in {}\n", t)
 		return ignoreMe
 	}
 }
 
-// Checks that we have a statement depth of 0. It's an error to exit
-// the parser with a depth of > 0, it means we are missing closing
+// checkStatementDepthIsZero checks that we aren't missing closing
 // braces. Note: the parser will error out for the case where we
-// start with an unmatched close brace, eg. depth < 0
+// start with an unmatched close brace, i.e. depth < 0
 //
-// This test is only done if there are no other errors as
+// This test should only be done if there are no other errors as
 // we may exit early due to those errors -- and therefore there *might*
 // not really be a mismatched brace issue.
-func (p *parser) checkStatementDepth() {
-	if p.errout.Len() > 0 || p.statementDepth < 1 {
+func (p *parser) checkStatementDepthIsZero() {
+	if p.errout.Len() > 0 || p.statementDepth == 0 {
 		return
 	}
 

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -151,7 +151,7 @@ func (s *Statement) Write(w io.Writer, indent string) error {
 	return nil
 }
 
-// ignoreMe is an error recovery non-terminal token used by the parser in order
+// ignoreMe is an error recovery token used by the parser in order
 // to continue processing for other errors in the file.
 var ignoreMe = &Statement{}
 

--- a/pkg/yang/parse.go
+++ b/pkg/yang/parse.go
@@ -151,7 +151,7 @@ func (s *Statement) Write(w io.Writer, indent string) error {
 	return nil
 }
 
-// ignoreMe is an error recovery non-terminal used by the parser in
+// ignoreMe is an error recovery terminal used by the parser in
 // order to continue processing for other errors in the file.
 var ignoreMe = &Statement{}
 

--- a/pkg/yang/parse_test.go
+++ b/pkg/yang/parse_test.go
@@ -229,18 +229,18 @@ id
 		{line: line(), in: `
    {
 `,
-			err: `test.yang:2:4: {: not an identifier`,
+			err: `test.yang:2:4: {: keyword token not an unquoted string`,
 		},
 		{line: line(), in: `
 ;
 `,
-			err: `test.yang:2:1: ;: not an identifier`,
+			err: `test.yang:2:1: ;: keyword token not an unquoted string`,
 		},
 		{line: line(), in: `
 statement one two { }
 `,
-			err: `test.yang:2:15: two: syntax error
-test.yang:2:19: {: not an identifier
+			err: `test.yang:2:15: two: syntax error, expected ';' or nested statements in {}
+test.yang:2:19: {: keyword token not an unquoted string
 test.yang:2:21: unexpected }`,
 		},
 		{line: line(), in: `
@@ -262,7 +262,7 @@ foo {
 		key3: "value\3;
 	}
 }`,
-			err: `test.yang:2:1: {: not an identifier
+			err: `test.yang:2:1: {: keyword token not an unquoted string
 test.yang:4:1: unexpected }
 test.yang:6:8: invalid escape sequence: \V
 test.yang:9:15: invalid escape sequence: \3


### PR DESCRIPTION
- Remove unused exported function `FakeStatement`.
- Simplify by replacing `closeBrace` and `openBrace` with their character values.
- Rename `tIdentifier` to `tUnquoted`. Identifiers can be quoted in YANG, so this name is confusing. The original author intended these to be unquoted strings.
- Improve comments in the parser.