### PR TITLE
Add MatchingEntryExtensions() to search extensions added during uses/augment/include statements

### DIFF
--- a/pkg/yang/node.go
+++ b/pkg/yang/node.go
@@ -127,12 +127,24 @@ func FindModuleByPrefix(n Node, prefix string) *Module {
 // MatchingExtensions returns the subset of the given node's extensions
 // that match the given module and identifier.
 func MatchingExtensions(n Node, module, identifier string) ([]*Statement, error) {
+	return matchingExtensions(n, n.Exts(), module, identifier)
+}
+
+// MatchingEntryExtensions returns the subset of the given entry's extensions
+// that match the given module and identifier.
+func MatchingEntryExtensions(e *Entry, module, identifier string) ([]*Statement, error) {
+	return matchingExtensions(e.Node, e.Exts, module, identifier)
+}
+
+// matchingEntryExtensions returns the subset of the given node's extensions
+// that match the given module and identifier.
+func matchingExtensions(n Node, exts []*Statement, module, identifier string) ([]*Statement, error) {
 	var matchingExtensions []*Statement
-	for _, ext := range n.Exts() {
+	for _, ext := range exts {
 		names := strings.SplitN(ext.Keyword, ":", 2)
 		mod := FindModuleByPrefix(n, names[0])
 		if mod == nil {
-			return nil, fmt.Errorf("MatchingExtensions: module prefix %q not found", names[0])
+			return nil, fmt.Errorf("matchingExtensions: module prefix %q not found", names[0])
 		}
 		if len(names) == 2 && names[1] == identifier && mod.Name == module {
 			matchingExtensions = append(matchingExtensions, ext)

--- a/pkg/yang/node_test.go
+++ b/pkg/yang/node_test.go
@@ -174,7 +174,7 @@ func TestNode(t *testing.T) {
 			return nil
 		},
 	}, {
-		desc: "Test MatchingExtensions",
+		desc: "Test matchingExtensions",
 		inFn: func(ms *Modules) (Node, error) {
 
 			m, err := ms.FindModuleByPrefix("t")
@@ -267,7 +267,7 @@ func TestNode(t *testing.T) {
 			}
 
 			var bars []string
-			matches, err := MatchingExtensions(n, "foo", "bar")
+			matches, err := matchingExtensions(n, n.Exts(), "foo", "bar")
 			if err != nil {
 				return err
 			}
@@ -276,13 +276,13 @@ func TestNode(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(bars, []string{"boo", "coo", "foo"}); diff != "" {
-				return fmt.Errorf("MatchingExtensions (-got, +want):\n%s", diff)
+				return fmt.Errorf("matchingExtensions (-got, +want):\n%s", diff)
 			}
 
 			return nil
 		},
 	}, {
-		desc: "Test MatchingExtensions when module is not found",
+		desc: "Test matchingExtensions when module is not found",
 		inFn: func(ms *Modules) (Node, error) {
 
 			m, err := ms.FindModuleByPrefix("t")
@@ -342,7 +342,7 @@ func TestNode(t *testing.T) {
 			}
 
 			var bars []string
-			matches, err := MatchingExtensions(n, "foo", "bar")
+			matches, err := matchingExtensions(n, n.Exts(), "foo", "bar")
 			if err != nil {
 				return err
 			}
@@ -351,7 +351,7 @@ func TestNode(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(bars, []string{"boo", "coo", "foo"}); diff != "" {
-				return fmt.Errorf("MatchingExtensions (-got, +want):\n%s", diff)
+				return fmt.Errorf("matchingExtensions (-got, +want):\n%s", diff)
 			}
 
 			return nil


### PR DESCRIPTION
`MatchingExtensions` currently takes in `yang.Node`, which is not quite usable when the user is mostly operating on `yang.Entry` objects.

I think the current `MatchingExtensions` implementation might still be useful in case the user wants to look into the extensions of non-Entry nodes, such as `yang.Type`.