### PR TITLE
Export Module.modules

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -169,7 +169,7 @@ func (e *Entry) Modules() *Modules {
 	for e.Parent != nil {
 		e = e.Parent
 	}
-	return e.Node.(*Module).modules
+	return e.Node.(*Module).Modules
 }
 
 // IsDir returns true if e is a directory.
@@ -541,7 +541,7 @@ func ToEntry(n Node) (e *Entry) {
 			Errors: []error{err},
 		}
 	}
-	ms := RootNode(n).modules
+	ms := RootNode(n).Modules
 	if e := entryCache[n]; e != nil {
 		return e
 	}
@@ -1255,7 +1255,7 @@ func (e *Entry) Find(name string) *Entry {
 		for _, i := range e.Node.(*Module).Import {
 			// Resolve the module using the current module set, since we may
 			// not have populated the Module for the entry yet.
-			m, ok := e.Node.(*Module).modules.Modules[i.Name]
+			m, ok := e.Node.(*Module).Modules.Modules[i.Name]
 			if !ok {
 				e.addError(fmt.Errorf("cannot find a module with name %s when looking at imports in %s", i.Name, e.Path()))
 				return nil
@@ -1340,7 +1340,7 @@ func (e *Entry) Namespace() *Value {
 	if e != nil && e.Node != nil {
 		if root := RootNode(e.Node); root != nil {
 			if root.Kind() == "submodule" {
-				root = root.modules.Modules[root.BelongsTo.Name]
+				root = root.Modules.Modules[root.BelongsTo.Name]
 				if root == nil {
 					return new(Value)
 				}

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -143,7 +143,7 @@ func (ms *Modules) add(n Node) error {
 
 	mod := n.(*Module)
 	fullName := mod.FullName()
-	mod.modules = ms
+	mod.Modules = ms
 
 	if o := m[fullName]; o != nil {
 		return fmt.Errorf("duplicate %s %s at %s and %s", kind, fullName, Source(o), Source(n))

--- a/pkg/yang/node.go
+++ b/pkg/yang/node.go
@@ -204,7 +204,7 @@ func FindNode(n Node, path string) (Node, error) {
 		mod := n.(*Module)
 		prefix, _ := getPrefix(parts[0])
 		if mod.Kind() == "submodule" {
-			m := mod.modules.Modules[mod.BelongsTo.Name]
+			m := mod.Modules.Modules[mod.BelongsTo.Name]
 			if m == nil {
 				return nil, fmt.Errorf("%s: unknown module %s", m.Name, mod.BelongsTo.Name)
 			}

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -134,12 +134,9 @@ type Module struct {
 	Uses         []*Uses         `yang:"uses"`
 	YangVersion  *Value          `yang:"yang-version,nomerge"`
 
-	// modules is used to get back to the Modules structure
-	// when searching for a rooted element in the schema tree
-	// as the schema tree has multiple root elements.
-	// typedefs is a list of all top level typedefs in this
-	// module.
-	modules *Modules
+	// Modules references the Modules object from which this Module node
+	// was parsed.
+	Modules *Modules
 }
 
 func (s *Module) Kind() string {


### PR DESCRIPTION
Downstream code that tests using Entry objects (e.g. ygot) might
be blocked by this if they are manually created, since `modules` can
only be populated when Entry objects are created using the `Modules`
object and methods.

I don't see a reason for keeping it unexported, so creating this PR.