### PR TITLE
Simplify resolved identity look-up by using mname:basename and support YANG1.1 scoping.

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1242,10 +1242,7 @@ func (e *Entry) Find(name string) *Entry {
 			e = e.Parent
 		}
 		if prefix, _ := getPrefix(parts[0]); prefix != "" {
-			m := FindModuleByPrefix(contextNode, prefix)
-			if m.Kind() == "submodule" {
-				m = m.Modules.Modules[m.BelongsTo.Name]
-			}
+			m := module(FindModuleByPrefix(contextNode, prefix))
 			if m == nil {
 				e.addError(fmt.Errorf("cannot find module giving prefix %q within context entry %q", prefix, e.Path()))
 				return nil

--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -29,7 +29,7 @@ type identityDictionary struct {
 	// dict is a global cache of identities keyed by
 	// modulename:identityname, where modulename is the full name of the
 	// module to which the identity belongs. If the identity were defined
-	// in a submodule, then the belonging module name is used instead.
+	// in a submodule, then the parent module name is used instead.
 	dict map[string]resolvedIdentity
 }
 
@@ -107,9 +107,7 @@ func (mod *Module) findIdentityBase(baseStr string) (*resolvedIdentity, []error)
 				fmt.Errorf("%s: can't find external module with prefix %s", source, basePrefix))
 			break
 		}
-		// The identity we are looking for is modulename:basename.  If
-		// we already know modulename:basename then just use it.  If not,
-		// try again within the module identified by prefix.
+		// The identity we are looking for is modulename:basename.
 		if id, ok := identities.dict[fmt.Sprintf("%s:%s", module(extmod).Name, baseName)]; ok {
 			base = id
 			break

--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -26,8 +26,10 @@ import (
 // to be identified by their module and name.
 type identityDictionary struct {
 	mu sync.Mutex
-	// TODO(wenovus): The key should not be prefix:ident-name, but
-	// module-name:ident-name. Prefixes are NOT unique.
+	// dict is a global cache of identities keyed by
+	// modulename:identityname, where modulename is the full name of the
+	// module to which the identity belongs. If the identity were defined
+	// in a submodule, then the belonging module name is used instead.
 	dict map[string]resolvedIdentity
 }
 
@@ -53,7 +55,7 @@ func newResolvedIdentity(m *Module, i *Identity) (string, *resolvedIdentity) {
 		Module:   m,
 		Identity: i,
 	}
-	return i.PrefixedName(), r
+	return i.modulePrefixedName(), r
 }
 
 func appendIfNotIn(ids []*Identity, chk *Identity) []*Identity {
@@ -78,7 +80,7 @@ func addChildren(r *Identity, ids []*Identity) []*Identity {
 }
 
 // findIdentityBase returns the resolved identity that is corresponds to the
-// baseStr string in the context of the Module mod.
+// baseStr string in the context of the module/submodule mod.
 func (mod *Module) findIdentityBase(baseStr string) (*resolvedIdentity, []error) {
 	var base resolvedIdentity
 	var ok bool
@@ -92,19 +94,12 @@ func (mod *Module) findIdentityBase(baseStr string) (*resolvedIdentity, []error)
 	case "", rootPrefix:
 		// This is a local identity which is defined within the current
 		// module
-		keyName := fmt.Sprintf("%s:%s", rootPrefix, baseName)
+		keyName := fmt.Sprintf("%s:%s", module(mod).Name, baseName)
 		base, ok = identities.dict[keyName]
 		if !ok {
 			errs = append(errs, fmt.Errorf("%s: can't resolve the local base %s as %s", source, baseStr, keyName))
 		}
 	default:
-		// The identity we are looking for is prefix:basename.  If
-		// we already know prefix:basename then just use it.  If not,
-		// try again within the module identified by prefix.
-		if id, ok := identities.dict[baseStr]; ok {
-			base = id
-			break
-		}
 		// This is an identity which is defined within another module
 		extmod := FindModuleByPrefix(mod, basePrefix)
 		if extmod == nil {
@@ -112,20 +107,14 @@ func (mod *Module) findIdentityBase(baseStr string) (*resolvedIdentity, []error)
 				fmt.Errorf("%s: can't find external module with prefix %s", source, basePrefix))
 			break
 		}
-
-		// Run through the identities within the remote module and find the
-		// one that matches the base that we have been specified.
-		for _, rid := range extmod.Identities() {
-			if rid.Name == baseName {
-				key := rid.PrefixedName()
-				if id, ok := identities.dict[key]; ok {
-					base = id
-				} else {
-					errs = append(errs, fmt.Errorf("%s: can't find base %s", source, baseStr))
-				}
-				break
-			}
+		// The identity we are looking for is modulename:basename.  If
+		// we already know modulename:basename then just use it.  If not,
+		// try again within the module identified by prefix.
+		if id, ok := identities.dict[fmt.Sprintf("%s:%s", module(extmod).Name, baseName)]; ok {
+			base = id
+			break
 		}
+
 		// Error if we did not find the identity that had the name specified in
 		// the module it was expected to be in.
 		if base.isEmpty() {

--- a/pkg/yang/identity_test.go
+++ b/pkg/yang/identity_test.go
@@ -218,11 +218,7 @@ func TestIdentityExtract(t *testing.T) {
 			foundIdentity := false
 			var thisID *Identity
 			for _, ri := range identities.dict {
-				// TODO(wenbli): Use definingModule helper from ygot after it's moved to goyang.
-				moduleName := ri.Module.Name
-				if ri.Module.Kind() == "submodule" {
-					moduleName = ri.Module.BelongsTo.Name
-				}
+				moduleName := module(ri.Module).Name
 				if ri.Identity.Name == ti.name && moduleName == ti.module {
 					foundIdentity = true
 					thisID = ri.Identity
@@ -253,6 +249,43 @@ func TestIdentityExtract(t *testing.T) {
 // Test cases for validating that identities can be resolved correctly.
 var treeTestCases = []identityTestCase{
 	{
+		name: "tree-test-case-0: Validate identity resolution across submodules",
+		in: []inputModule{
+			{
+				name: "base.yang",
+				content: `
+				  module base {
+				    namespace "urn:base";
+				    prefix "base";
+
+				    include side;
+
+				    identity REMOTE_BASE;
+				  }
+				`},
+			{
+				name: "remote.yang",
+				content: `
+				  submodule side {
+				    belongs-to base {
+				      prefix "r";
+				    }
+
+				    identity LOCAL_REMOTE_BASE {
+				      base r:REMOTE_BASE;
+				    }
+				  }
+				`},
+		},
+		identities: []identityOut{
+			{
+				module: "base",
+				name:   "REMOTE_BASE",
+				values: []string{"LOCAL_REMOTE_BASE"},
+			},
+		},
+	},
+	{
 		name: "tree-test-case-1: Validate identity resolution across modules",
 		in: []inputModule{
 			{
@@ -263,9 +296,14 @@ var treeTestCases = []identityTestCase{
 				    prefix "base";
 
 				    import remote { prefix "r"; }
+				    import remote2 { prefix "r2"; }
 
 				    identity LOCAL_REMOTE_BASE {
 				      base r:REMOTE_BASE;
+				    }
+
+				    identity LOCAL_REMOTE_BASE2 {
+				      base r2:REMOTE_BASE2;
 				    }
 				  }
 				`},
@@ -274,9 +312,19 @@ var treeTestCases = []identityTestCase{
 				content: `
 				  module remote {
 				    namespace "urn:remote";
-				    prefix "remote";
+				    prefix "r";
 
 				    identity REMOTE_BASE;
+				  }
+				`},
+			{
+				name: "remote2.yang",
+				content: `
+				  module remote2 {
+				    namespace "urn:remote2";
+				    prefix "remote";
+
+				    identity REMOTE_BASE2;
 				  }
 				`},
 		},
@@ -287,9 +335,19 @@ var treeTestCases = []identityTestCase{
 				values: []string{"LOCAL_REMOTE_BASE"},
 			},
 			{
+				module: "remote2",
+				name:   "REMOTE_BASE2",
+				values: []string{"LOCAL_REMOTE_BASE2"},
+			},
+			{
 				module:    "base",
 				name:      "LOCAL_REMOTE_BASE",
 				baseNames: []string{"r:REMOTE_BASE"},
+			},
+			{
+				module:    "base",
+				name:      "LOCAL_REMOTE_BASE2",
+				baseNames: []string{"r2:REMOTE_BASE2"},
 			},
 		},
 	},
@@ -647,6 +705,7 @@ func TestIdentityTree(t *testing.T) {
 				if foundID == nil {
 					t.Errorf("Couldn't find identity %s in module %s", chkID.name,
 						chkID.module)
+					continue
 				}
 
 				if len(chkID.baseNames) > 0 {

--- a/pkg/yang/node.go
+++ b/pkg/yang/node.go
@@ -152,6 +152,17 @@ func RootNode(n Node) *Module {
 	return nil
 }
 
+// module returns the Module to which n belongs. If n resides in a submodule,
+// the belonging module will be returned.
+// If n is nil or a module could not be find, nil is returned.
+func module(n Node) *Module {
+	m := RootNode(n)
+	if m.Kind() == "submodule" {
+		m = m.Modules.Modules[m.BelongsTo.Name]
+	}
+	return m
+}
+
 // NodePath returns the full path of the node from the module name.
 func NodePath(n Node) string {
 	var path string

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -835,6 +835,11 @@ func (s *Identity) PrefixedName() string {
 	return fmt.Sprintf("%s:%s", RootNode(s).GetPrefix(), s.Name)
 }
 
+// modulePrefixedName returns the module-qualified name for the identity.
+func (s *Identity) modulePrefixedName() string {
+	return fmt.Sprintf("%s:%s", module(s).Name, s.Name)
+}
+
 // IsDefined behaves the same as the implementation for Enum - it returns
 // true if an identity with the name is defined within the Values of the
 // identity


### PR DESCRIPTION
Fixes #173.

It was previously caching `prefix:basename`, and if there is a non-matching name, it would then do the correct prefix-resolution and then another loop across the identities.

Since `modulename:basename` is being used, I've removed this now redundant second loop.

Furthermore, the old resolution mechanism didn't allow searching for a name defined outside of the module/submodule file, which the current resolution mechanism now supports (`test-case-0`).