### PR TITLE
Ignore extra error tokens.

### DIFF
--- a/pkg/yang/lex_test.go
+++ b/pkg/yang/lex_test.go
@@ -277,6 +277,20 @@ without an ending.
 			`test.yang:1:1: missing closing */
 `,
 		},
+		{line(),
+			// Two errors too many.
+			`yang-version 1.1;description "\/\/\/\/\/\/\/\/\/\/";`,
+			9,
+			`test.yang:1:31: invalid escape sequence: \/
+test.yang:1:33: invalid escape sequence: \/
+test.yang:1:35: invalid escape sequence: \/
+test.yang:1:37: invalid escape sequence: \/
+test.yang:1:39: invalid escape sequence: \/
+test.yang:1:41: invalid escape sequence: \/
+test.yang:1:43: invalid escape sequence: \/
+test.yang:1:45: invalid escape sequence: \/
+` + tooMany,
+		},
 	} {
 		l := newLexer(tt.in, "test.yang")
 		errbuf := &bytes.Buffer{}


### PR DESCRIPTION
An alternative that fixes #116.

This is essentially what @pborman proposed in https://github.com/openconfig/goyang/pull/117#issuecomment-616119988.

I wasn't able to reproduce test failing as mentioned by @andaru in https://github.com/openconfig/goyang/pull/117#issuecomment-622232317 in the current codebase, so pborman's suggestion now makes more sense.

The reason seems to be that error tokens are always skipped, so they don't seem to affect `Location` as Andrew mentioned:
https://github.com/openconfig/goyang/blob/1fb7893798e04830b4d7fbbcd6672b95668fcf73/pkg/yang/parse.go#L207-L214