### PR TITLE
factor out `d *typeDictionary` as a parameter to `initTypes`.

### DIFF
--- a/pkg/yang/ast_test.go
+++ b/pkg/yang/ast_test.go
@@ -517,7 +517,7 @@ alt_node the_node {
 		}
 
 		typeDict := newTypeDictionary()
-		initTypes(reflect.TypeOf(&meta{}), typeDict)
+		initTypes(reflect.TypeOf(&meta{}))
 
 		ast, err := buildASTWithTypeDict(ss[0], typeDict)
 		switch {

--- a/pkg/yang/bgp_test.go
+++ b/pkg/yang/bgp_test.go
@@ -32,7 +32,7 @@ func TestBGP(t *testing.T) {
 		t.Fatalf("got %d results, want 1", len(ss))
 	}
 	typeDict := newTypeDictionary()
-	initTypes(reflect.TypeOf(&meta{}), typeDict)
+	initTypes(reflect.TypeOf(&meta{}))
 	if _, err := buildASTWithTypeDict(ss[0], typeDict); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -441,16 +441,6 @@ func (e *Entry) GetWhenXPath() (string, bool) {
 	return "", false
 }
 
-// entryCache is used to prevent unnecessary recursion into previously
-// converted nodes.
-var entryCache = map[Node]*Entry{}
-
-// mergedSubmodule is used to prevent re-parsing a submodule that has already
-// been merged into a particular entity when circular dependencies are being
-// ignored. The keys of the map are a string that is formed by concatenating
-// the name of the including (sub)module and the included submodule.
-var mergedSubmodule = map[string]bool{}
-
 // deviationType specifies an enumerated value covering the different substatements
 // to the deviate statement.
 type deviationType int64
@@ -542,11 +532,11 @@ func ToEntry(n Node) (e *Entry) {
 		}
 	}
 	ms := RootNode(n).Modules
-	if e := entryCache[n]; e != nil {
+	if e := ms.entryCache[n]; e != nil {
 		return e
 	}
 	defer func() {
-		entryCache[n] = e
+		ms.entryCache[n] = e
 	}()
 
 	// Copy in the extensions from our Node, if any.
@@ -763,14 +753,14 @@ func ToEntry(n Node) (e *Entry) {
 				includedToSrc := n.NName() + ":" + a.Module.Name
 
 				switch {
-				case mergedSubmodule[srcToIncluded]:
+				case ms.mergedSubmodule[srcToIncluded]:
 					// We have already merged this module, so don't try and do it
 					// again.
 					continue
-				case !mergedSubmodule[includedToSrc] && a.Module.NName() != n.NName():
+				case !ms.mergedSubmodule[includedToSrc] && a.Module.NName() != n.NName():
 					// We have not merged A->B, and B != B hence go ahead and merge.
 					includedToParent := a.Module.Name + ":" + a.Module.BelongsTo.Name
-					if mergedSubmodule[includedToParent] {
+					if ms.mergedSubmodule[includedToParent] {
 						// Don't try and re-import submodules that have already been imported
 						// into the top-level module. Note that this ensures that we get to the
 						// top the tree (whichever the actual module for the chain of
@@ -779,8 +769,8 @@ func ToEntry(n Node) (e *Entry) {
 						// walking through a sub-cycle of the include graph.
 						continue
 					}
-					mergedSubmodule[srcToIncluded] = true
-					mergedSubmodule[includedToParent] = true
+					ms.mergedSubmodule[srcToIncluded] = true
+					ms.mergedSubmodule[includedToParent] = true
 					e.merge(a.Module.Prefix, nil, ToEntry(a.Module))
 				case ParseOptions.IgnoreSubmoduleCircularDependencies:
 					continue

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1532,7 +1532,6 @@ func TestFullModuleProcess(t *testing.T) {
 
 	for _, tt := range tests {
 		ms := NewModules()
-		mergedSubmodule = map[string]bool{}
 
 		ParseOptions.IgnoreSubmoduleCircularDependencies = tt.inIgnoreCircDeps
 		for n, m := range tt.inModules {
@@ -3200,7 +3199,6 @@ func TestDeviation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ms := NewModules()
-			mergedSubmodule = map[string]bool{}
 
 			for name, mod := range tt.inFiles {
 				if err := ms.Parse(mod, name); err != nil {

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -20,7 +20,6 @@ package yang
 
 import (
 	"fmt"
-	"reflect"
 )
 
 // Modules contains information about all the top level modules and
@@ -44,7 +43,6 @@ func NewModules() *Modules {
 		byNS:       map[string]*Module{},
 		typeDict:   newTypeDictionary(),
 	}
-	initTypes(reflect.TypeOf(&meta{}), ms.typeDict)
 	return ms
 }
 


### PR DESCRIPTION
Also call `initTypes` on `init()` only. This confirms that the global
variables `typeMap`, `nameMap`, `aliases` are always the same values, so
that they don't need to be created per instance of the `Modules` object.

This refactor is preparation work for #172 (allowing multiple sets of modules to be processed independently).