### PR TITLE
factor out `d *typeDictionary` as a parameter to `initTypes`.

### DIFF
--- a/pkg/yang/ast_test.go
+++ b/pkg/yang/ast_test.go
@@ -517,7 +517,7 @@ alt_node the_node {
 		}
 
 		typeDict := newTypeDictionary()
-		initTypes(reflect.TypeOf(&meta{}), typeDict)
+		initTypes(reflect.TypeOf(&meta{}))
 
 		ast, err := buildASTWithTypeDict(ss[0], typeDict)
 		switch {

--- a/pkg/yang/bgp_test.go
+++ b/pkg/yang/bgp_test.go
@@ -32,7 +32,7 @@ func TestBGP(t *testing.T) {
 		t.Fatalf("got %d results, want 1", len(ss))
 	}
 	typeDict := newTypeDictionary()
-	initTypes(reflect.TypeOf(&meta{}), typeDict)
+	initTypes(reflect.TypeOf(&meta{}))
 	if _, err := buildASTWithTypeDict(ss[0], typeDict); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -20,7 +20,6 @@ package yang
 
 import (
 	"fmt"
-	"reflect"
 )
 
 // Modules contains information about all the top level modules and
@@ -44,7 +43,6 @@ func NewModules() *Modules {
 		byNS:       map[string]*Module{},
 		typeDict:   newTypeDictionary(),
 	}
-	initTypes(reflect.TypeOf(&meta{}), ms.typeDict)
 	return ms
 }
 


### PR DESCRIPTION
Also call `initTypes` on `init()` only. This confirms that the global
variables `typeMap`, `nameMap`, `aliases` are always the same values, so
that they don't need to be created per instance of the `Modules` object.

This refactor is preparation work for #172 (allowing multiple sets of modules to be processed independently).