### PR TITLE
Move `Path` and `pathMap` under `Modules` to allow parsing of two different sets of files with different paths.

### DIFF
--- a/pkg/util/build_yang.go
+++ b/pkg/util/build_yang.go
@@ -29,11 +29,11 @@ import (
 // parsed top level modules. It also returns a list of errors encountered while
 // parsing, if any.
 func ProcessModules(yangfiles, path []string) (map[string]*yang.Entry, []error) {
-	for _, p := range path {
-		yang.AddPath(fmt.Sprintf("%s/...", p))
-	}
-
 	ms := yang.NewModules()
+
+	for _, p := range path {
+		ms.AddPath(fmt.Sprintf("%s/...", p))
+	}
 
 	var processErr []error
 	for _, name := range yangfiles {

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -43,6 +43,10 @@ type Modules struct {
 	// directly set by the caller to influence how goyang will behave in the presence
 	// of certain exceptional cases.
 	ParseOptions Options
+	// Path is the list of directories to look for .yang files in.
+	Path []string
+	// pathMap is used to prevent adding dups in Path.
+	pathMap map[string]bool
 }
 
 // NewModules returns a newly created and initialized Modules.
@@ -56,6 +60,7 @@ func NewModules() *Modules {
 		typeDict:        newTypeDictionary(),
 		mergedSubmodule: map[string]bool{},
 		entryCache:      map[Node]*Entry{},
+		pathMap:         map[string]bool{},
 	}
 	return ms
 }
@@ -65,7 +70,7 @@ func NewModules() *Modules {
 // e.g., foo.yang is named foo).  An error is returned if the file is not
 // found or there was an error parsing the file.
 func (ms *Modules) Read(name string) error {
-	name, data, err := findFile(name)
+	name, data, err := ms.findFile(name)
 	if err != nil {
 		return err
 	}

--- a/yang.go
+++ b/yang.go
@@ -149,13 +149,16 @@ Formats:
 		stop(0)
 	}
 
+	ms := yang.NewModules()
+	ms.ParseOptions.IgnoreSubmoduleCircularDependencies = ignoreSubmoduleCircularDependencies
+
 	for _, path := range paths {
 		expanded, err := yang.PathsWithModules(path)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			continue
 		}
-		yang.AddPath(expanded...)
+		ms.AddPath(expanded...)
 	}
 
 	if format == "" {
@@ -168,9 +171,6 @@ Formats:
 	}
 
 	files := getopt.Args()
-
-	ms := yang.NewModules()
-	ms.ParseOptions.IgnoreSubmoduleCircularDependencies = ignoreSubmoduleCircularDependencies
 
 	if len(files) == 0 {
 		data, err := ioutil.ReadAll(os.Stdin)


### PR DESCRIPTION
Fixes #172