### PR TITLE
Adding Extras to JSON - fixes #211

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 Paul Borman <borman@google.com>
 Andrew Fort <afort@arista.com>
 Rob Shakir <robjs@google.com>
+Sean Condon <sean@opennetworking.org>

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -120,7 +120,7 @@ type Entry struct {
 	Uses            []*UsesStmt `json:",omitempty"` // Uses merged into this entry.
 
 	// Extra maps all the unsupported fields to their values
-	Extra map[string][]interface{} `json:",omitempty"`
+	Extra map[string][]interface{} `json:"extra-unsupported-unstable,omitempty"`
 
 	// Annotation stores annotated values, and is not populated by this
 	// library but rather can be used by calling code where additional

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -120,7 +120,7 @@ type Entry struct {
 	Uses            []*UsesStmt `json:",omitempty"` // Uses merged into this entry.
 
 	// Extra maps all the unsupported fields to their values
-	Extra map[string][]interface{} `json:"-"`
+	Extra map[string][]interface{} `json:",omitempty"`
 
 	// Annotation stores annotated values, and is not populated by this
 	// library but rather can be used by calling code where additional
@@ -980,7 +980,9 @@ func ToEntry(n Node) (e *Entry) {
 			"unique",
 			"when",
 			"yang-version":
-			e.Extra[name] = append(e.Extra[name], fv.Interface())
+			if !fv.IsNil() {
+				addToExtrasSlice(fv, name, e)
+			}
 			continue
 
 		case "Ext", "Name", "Parent", "Statement":
@@ -1024,8 +1026,27 @@ func addExtraKeywordsToLeafEntry(n Node, e *Entry) {
 			"reference",
 			"status",
 			"when":
-			e.Extra[name] = append(e.Extra[name], fv.Interface())
+			if !fv.IsNil() {
+				addToExtrasSlice(fv, name, e)
+			}
 		}
+	}
+}
+
+func addToExtrasSlice(fv reflect.Value, name string, e *Entry) {
+	if fv.Kind() == reflect.Slice {
+	outerLoop:
+		for j := 0; j < fv.Len(); j++ {
+			for _, en := range e.Extra[name] {
+				if en == fv.Index(j).Interface() {
+					// Don't add again if identical
+					continue outerLoop
+				}
+			}
+			e.Extra[name] = append(e.Extra[name], fv.Index(j).Interface())
+		}
+	} else {
+		e.Extra[name] = append(e.Extra[name], fv.Interface())
 	}
 }
 

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -120,7 +120,7 @@ type Entry struct {
 	Uses            []*UsesStmt `json:",omitempty"` // Uses merged into this entry.
 
 	// Extra maps all the unsupported fields to their values
-	Extra map[string][]interface{} `json:"extra-unsupported-unstable,omitempty"`
+	Extra map[string][]interface{} `json:"extra-unstable,omitempty"`
 
 	// Annotation stores annotated values, and is not populated by this
 	// library but rather can be used by calling code where additional

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -626,7 +626,6 @@ func ToEntry(n Node) (e *Entry) {
 			e.addError(err)
 		}
 		e.Prefix = getRootPrefix(e)
-		addExtraKeywordsToLeafEntry(n, e)
 		return e
 	case *Uses:
 		g := FindGrouping(s, s.Name, map[string]bool{})
@@ -1035,14 +1034,7 @@ func addExtraKeywordsToLeafEntry(n Node, e *Entry) {
 
 func addToExtrasSlice(fv reflect.Value, name string, e *Entry) {
 	if fv.Kind() == reflect.Slice {
-	outerLoop:
 		for j := 0; j < fv.Len(); j++ {
-			for _, en := range e.Extra[name] {
-				if en == fv.Index(j).Interface() {
-					// Don't add again if identical
-					continue outerLoop
-				}
-			}
 			e.Extra[name] = append(e.Extra[name], fv.Index(j).Interface())
 		}
 	} else {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -2006,13 +2006,18 @@ func TestIfFeature(t *testing.T) {
 		if len(extra) == 0 {
 			return nil
 		}
-		return extra[0].([]*Value)
+		values := make([]*Value, len(extra))
+		for i, ex := range extra {
+			values[i] = ex.(*Value)
+		}
+		return values
 	}
 
 	featureByName := func(e *Entry, name string) *Feature {
-		for _, f := range e.Extra["feature"][0].([]*Feature) {
-			if f.Name == name {
-				return f
+		for _, f := range e.Extra["feature"] {
+			ft := f.(*Feature)
+			if ft.Name == name {
+				return ft
 			}
 		}
 		return nil

--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -662,7 +662,7 @@ func TestParseAndMarshal(t *testing.T) {
       "Name": "DERIVED"
     }
   ],
-  "Extra": {
+  "extra-unsupported-unstable": {
     "namespace": [
       {
         "Name": "urn:t",
@@ -741,7 +741,7 @@ func TestParseAndMarshal(t *testing.T) {
       ]
     }
   },
-  "Extra": {
+  "extra-unsupported-unstable": {
     "namespace": [
       {
         "Name": "urn:t",
@@ -766,7 +766,7 @@ func TestParseAndMarshal(t *testing.T) {
       "Argument": "e"
     }
   },
-  "Extra": {
+  "extra-unsupported-unstable": {
     "extension": [
       {
         "Name": "foobar",

--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -661,7 +661,19 @@ func TestParseAndMarshal(t *testing.T) {
     {
       "Name": "DERIVED"
     }
-  ]
+  ],
+  "Extra": {
+    "namespace": [
+      {
+        "Name": "urn:t",
+        "Source": {
+          "Keyword": "namespace",
+          "HasArgument": true,
+          "Argument": "urn:t"
+        }
+      }
+    ]
+  }
 }`,
 		},
 	}, {
@@ -728,6 +740,18 @@ func TestParseAndMarshal(t *testing.T) {
         }
       ]
     }
+  },
+  "Extra": {
+    "namespace": [
+      {
+        "Name": "urn:t",
+        "Source": {
+          "Keyword": "namespace",
+          "HasArgument": true,
+          "Argument": "urn:t"
+        }
+      }
+    ]
   }
 }`,
 			"ext": `{
@@ -741,6 +765,26 @@ func TestParseAndMarshal(t *testing.T) {
       "HasArgument": true,
       "Argument": "e"
     }
+  },
+  "Extra": {
+    "extension": [
+      {
+        "Name": "foobar",
+        "Argument": {
+          "Name": "baz"
+        }
+      }
+    ],
+    "namespace": [
+      {
+        "Name": "urn:e",
+        "Source": {
+          "Keyword": "namespace",
+          "HasArgument": true,
+          "Argument": "urn:e"
+        }
+      }
+    ]
   }
 }`,
 		},

--- a/pkg/yang/marshal_test.go
+++ b/pkg/yang/marshal_test.go
@@ -662,7 +662,7 @@ func TestParseAndMarshal(t *testing.T) {
       "Name": "DERIVED"
     }
   ],
-  "extra-unsupported-unstable": {
+  "extra-unstable": {
     "namespace": [
       {
         "Name": "urn:t",
@@ -741,7 +741,7 @@ func TestParseAndMarshal(t *testing.T) {
       ]
     }
   },
-  "extra-unsupported-unstable": {
+  "extra-unstable": {
     "namespace": [
       {
         "Name": "urn:t",
@@ -766,7 +766,7 @@ func TestParseAndMarshal(t *testing.T) {
       "Argument": "e"
     }
   },
-  "extra-unsupported-unstable": {
+  "extra-unstable": {
     "extension": [
       {
         "Name": "foobar",

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -101,8 +101,8 @@ func (s *Value) asString() string {
 // A SubModule is defined in: http://tools.ietf.org/html/rfc6020#section-7.2
 type Module struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
 	Extensions []*Statement `yang:"Ext"`
 
 	Anydata      []*AnyData      `yang:"anydata"`
@@ -202,8 +202,8 @@ func (s *Module) getPrefix() *Value {
 // An Import is defined in: http://tools.ietf.org/html/rfc6020#section-7.1.5
 type Import struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
 	Extensions []*Statement `yang:"Ext"`
 
 	Prefix       *Value `yang:"prefix,required"`
@@ -225,9 +225,9 @@ func (s *Import) Exts() []*Statement    { return s.Extensions }
 // An Include is defined in: http://tools.ietf.org/html/rfc6020#section-7.1.6
 type Include struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
 	RevisionDate *Value `yang:"revision-date"`
 
@@ -245,9 +245,9 @@ func (s *Include) Exts() []*Statement    { return s.Extensions }
 // A Revision is defined in: http://tools.ietf.org/html/rfc6020#section-7.1.9
 type Revision struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
 	Description *Value `yang:"description"`
 	Reference   *Value `yang:"reference"`
@@ -262,9 +262,9 @@ func (s *Revision) Exts() []*Statement    { return s.Extensions }
 // A BelongsTo is defined in: http://tools.ietf.org/html/rfc6020#section-7.2.2
 type BelongsTo struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
 	Prefix *Value `yang:"prefix,required"`
 }
@@ -367,15 +367,15 @@ func (s *Container) Typedefs() []*Typedef   { return s.Typedef }
 
 // A Must is defined in: http://tools.ietf.org/html/rfc6020#section-7.5.3
 type Must struct {
-	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Name       string       `yang:"Name,nomerge" json:",omitempty"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
-	Description  *Value `yang:"description"`
-	ErrorAppTag  *Value `yang:"error-app-tag"`
-	ErrorMessage *Value `yang:"error-message"`
-	Reference    *Value `yang:"reference"`
+	Description  *Value `yang:"description" json:",omitempty"`
+	ErrorAppTag  *Value `yang:"error-app-tag" json:",omitempty"`
+	ErrorMessage *Value `yang:"error-message" json:",omitempty"`
+	Reference    *Value `yang:"reference" json:",omitempty"`
 }
 
 func (Must) Kind() string             { return "must" }
@@ -861,14 +861,14 @@ func (s *Identity) GetValue(name string) *Identity {
 // An Extension is defined in: http://tools.ietf.org/html/rfc6020#section-7.17
 type Extension struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
-	Argument    *Argument `yang:"argument"`
-	Description *Value    `yang:"description"`
-	Reference   *Value    `yang:"reference"`
-	Status      *Value    `yang:"status"`
+	Argument    *Argument `yang:"argument" json:",omitempty"`
+	Description *Value    `yang:"description" json:",omitempty"`
+	Reference   *Value    `yang:"reference" json:",omitempty"`
+	Status      *Value    `yang:"status" json:",omitempty"`
 }
 
 func (Extension) Kind() string             { return "extension" }
@@ -880,11 +880,11 @@ func (s *Extension) Exts() []*Statement    { return s.Extensions }
 // An Argument is defined in: http://tools.ietf.org/html/rfc6020#section-7.17.2
 type Argument struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
-	YinElement *Value `yang:"yin-element"`
+	YinElement *Value `yang:"yin-element" json:",omitempty"`
 }
 
 func (Argument) Kind() string             { return "argument" }
@@ -912,14 +912,14 @@ func (s *Element) Exts() []*Statement    { return s.Extensions }
 // A Feature is defined in: http://tools.ietf.org/html/rfc6020#section-7.18.1
 type Feature struct {
 	Name       string       `yang:"Name,nomerge"`
-	Source     *Statement   `yang:"Statement,nomerge"`
-	Parent     Node         `yang:"Parent,nomerge"`
-	Extensions []*Statement `yang:"Ext"`
+	Source     *Statement   `yang:"Statement,nomerge" json:"-"`
+	Parent     Node         `yang:"Parent,nomerge" json:"-"`
+	Extensions []*Statement `yang:"Ext" json:",omitempty"`
 
-	Description *Value   `yang:"description"`
-	IfFeature   []*Value `yang:"if-feature"`
-	Status      *Value   `yang:"status"`
-	Reference   *Value   `yang:"reference"`
+	Description *Value   `yang:"description" json:",omitempty"`
+	IfFeature   []*Value `yang:"if-feature" json:",omitempty"`
+	Status      *Value   `yang:"status" json:",omitempty"`
+	Reference   *Value   `yang:"reference" json:",omitempty"`
 }
 
 func (Feature) Kind() string             { return "feature" }


### PR DESCRIPTION
In this Patch I'm doing 2 things
1) Removing the exclusion of Extras from JSON, and excluding down the line the Parent and Source of Extra elements

2) Improving how items are added to the Extras slice. When the item is a Slice add its elements individually.

I can break this up in to 2 separate patches if necessary