### PR TITLE
Added modifier sub statement to pattern - rfc7950#section-9.4.5.1

### DIFF
--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -1046,7 +1046,7 @@ func (s *Length) Statement() *Statement { return s.Source }
 func (s *Length) Exts() []*Statement    { return s.Extensions }
 
 // A Pattern is defined in: http://tools.ietf.org/html/rfc6020#section-9.4.6
-//and http://tools.ietf.org/html/rfc7950#section-9.4.5.1 ("modifier" sub-statement)
+// and http://tools.ietf.org/html/rfc7950#section-9.4.5.1 ("modifier" sub-statement)
 type Pattern struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -1046,6 +1046,7 @@ func (s *Length) Statement() *Statement { return s.Source }
 func (s *Length) Exts() []*Statement    { return s.Extensions }
 
 // A Pattern is defined in: http://tools.ietf.org/html/rfc6020#section-9.4.6
+//and http://tools.ietf.org/html/rfc7950#section-9.4.5.1 ("modifier" sub-statement)
 type Pattern struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -1056,6 +1057,7 @@ type Pattern struct {
 	ErrorAppTag  *Value `yang:"error-app-tag"`
 	ErrorMessage *Value `yang:"error-message"`
 	Reference    *Value `yang:"reference"`
+	Modifier     *Value `yang:"modifier"`
 }
 
 func (Pattern) Kind() string             { return "pattern" }


### PR DESCRIPTION
As per https://www.rfc-editor.org/rfc/rfc7950#section-9.4.5.1, pattern type should support 'modifier' sub statement.
I have made the changes to support 'modifier' for pattern.