### PR TITLE
Retain Extra fields over transforming Uses and Augments to Entry 

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1485,6 +1485,13 @@ func (e *Entry) merge(prefix *Value, namespace *Value, oe *Entry) {
 		} else {
 			v.Parent = e
 			v.Exts = append(v.Exts, oe.Exts...)
+			for lk, lv := range oe.Extra {
+				if v.Extra[lk] == nil {
+					v.Extra[lk] = lv
+					continue
+				}
+				v.Extra[lk] = append(v.Extra[lk], oe.Extra[lk]...)
+			}
 			e.Dir[k] = v
 		}
 	}


### PR DESCRIPTION
Hi,

In a YANG model, _uses_ or _augments_ can be used to extend modules. It's possible to define under those nodes an _IfFeature_ attribute. But when turning those into an Entry (_yang.ToEntry_), _IfFeature_ field disappears. It should become an attribute located under _Extras_, but when using _Uses_, it simply isn't copied hence some information is lost.

This PR adds support for moving all the Extra fields defined in Uses or Merge to the augment element.