### PR TITLE
Retain Extra fields over Uses,Augments

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1485,6 +1485,13 @@ func (e *Entry) merge(prefix *Value, namespace *Value, oe *Entry) {
 		} else {
 			v.Parent = e
 			v.Exts = append(v.Exts, oe.Exts...)
+			for lk, lv := range oe.Extra {
+				if v.Extra[lk] == nil {
+					v.Extra[lk] = lv
+					continue
+				}
+				v.Extra[lk] = append(v.Extra[lk], oe.Extra[lk]...)
+			}
 			e.Dir[k] = v
 		}
 	}

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1461,6 +1461,12 @@ func (e *Entry) dup() *Entry {
 			ne.Dir[k] = de
 		}
 	}
+
+	ne.Extra = make(map[string][]interface{})
+	for k, v := range e.Extra {
+		ne.Extra[k] = v
+	}
+
 	return &ne
 }
 
@@ -1485,11 +1491,7 @@ func (e *Entry) merge(prefix *Value, namespace *Value, oe *Entry) {
 		} else {
 			v.Parent = e
 			v.Exts = append(v.Exts, oe.Exts...)
-			for lk, lv := range oe.Extra {
-				if v.Extra[lk] == nil {
-					v.Extra[lk] = lv
-					continue
-				}
+			for lk := range oe.Extra {
 				v.Extra[lk] = append(v.Extra[lk], oe.Extra[lk]...)
 			}
 			e.Dir[k] = v

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -2277,10 +2277,13 @@ func TestIfFeature(t *testing.T) {
 			wantIfFeatures: []string{"ft-uses"},
 		},
 		{
+			// Verify that if-feature field defined in "uses" is correctly propagated to container
 			name:           "uses",
 			inIfFeatures:   entryIfFeatures(mod.Dir["gc"]),
 			wantIfFeatures: []string{"ft-uses"},
-		}, {
+		},
+		{
+			// Verify that if-feature field defined in "augment" and in "augment > uses" is correctly propagated to container
 			name:           "augment-uses",
 			inIfFeatures:   entryIfFeatures(mod.Dir["cont"].Dir["gc"]),
 			wantIfFeatures: []string{"ft-augment-uses", "ft-augment"},

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -2058,6 +2058,7 @@ var testIfFeatureModules = []struct {
   feature ft-identity;
   feature ft-uses;
   feature ft-refine;
+  feature ft-augment-uses;
 
   container cont {
     if-feature ft-container;
@@ -2118,6 +2119,9 @@ var testIfFeatureModules = []struct {
 
   augment "/cont" {
     if-feature ft-augment;
+	uses g {
+		if-feature ft-augment-uses;
+	}
   }
 
   identity id {
@@ -2130,7 +2134,10 @@ var testIfFeatureModules = []struct {
       if-feature ft-refine;
     }
   }
-  grouping g {}
+
+  grouping g {
+	container gc {}
+  }
 }
 `,
 	},
@@ -2268,6 +2275,15 @@ func TestIfFeature(t *testing.T) {
 			name:           "uses",
 			inIfFeatures:   ms.Modules["if-feature"].Uses[0].IfFeature,
 			wantIfFeatures: []string{"ft-uses"},
+		},
+		{
+			name:           "uses",
+			inIfFeatures:   entryIfFeatures(mod.Dir["gc"]),
+			wantIfFeatures: []string{"ft-uses"},
+		}, {
+			name:           "augment-uses",
+			inIfFeatures:   entryIfFeatures(mod.Dir["cont"].Dir["gc"]),
+			wantIfFeatures: []string{"ft-augment-uses", "ft-augment"},
 		},
 	}
 


### PR DESCRIPTION
Hi,

In a YANG model, uses or augments can be used to extend modules. It's possible to define under those nodes an IfFeature attribute. But when turning those into an Entry (yang.ToEntry), IfFeature field disappears. It should become an attribute located under Extras, but when using Uses, it simply isn't copied hence some information is lost.

This PR adds support for moving all the Extra fields defined in Uses or Merge to the augment element.