### PR TITLE
Fix nil pointer dereference panic in `Find()` if module by prefix is not found

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1322,9 +1322,15 @@ func (e *Entry) Find(name string) *Entry {
 			e = e.Parent
 		}
 		if prefix, _ := getPrefix(parts[0]); prefix != "" {
-			m := module(FindModuleByPrefix(contextNode, prefix))
-			if m == nil {
+			mod := FindModuleByPrefix(contextNode, prefix)
+			if mod == nil {
 				e.addError(fmt.Errorf("cannot find module giving prefix %q within context entry %q", prefix, e.Path()))
+				return nil
+			}
+			m := module(mod)
+			if m == nil {
+				e.addError(fmt.Errorf("cannot find which module %q belongs to within context entry %q",
+					mod.NName(), e.Path()))
 				return nil
 			}
 			if m != e.Node.(*Module) {


### PR DESCRIPTION
Previously, if `FindModuleByPrefix()` returns nil in `Find()`, it would continue to call `module()` with nil, resulting in a nil pointer dereference panic when trying to call `ParentNode()` from `RootNode()`. The fix is to return an error if `FindModuleByPrefix()` returns nil.

Fixes #251