### PR TITLE
Add `ClearEntryCache()` to `Modules`

### DIFF
--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -442,3 +442,9 @@ func (ms *Modules) include(m *Module) error {
 	}
 	return nil
 }
+
+// ClearEntryCache clears the entryCache containing previously converted nodes
+// used by the ToEntry function.
+func (ms *Modules) ClearEntryCache() {
+	ms.entryCache = map[Node]*Entry{}
+}


### PR DESCRIPTION
This function clears the `entryCache` in `Modules` to free up memory after processing modules. `entryCache` is used by the `ToEntry` function to cache previously converted nodes.

Fixes #259