### PR TITLE
Protect `entryCache` with lock

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -559,11 +559,18 @@ func ToEntry(n Node) (e *Entry) {
 		}
 	}
 	ms := RootNode(n).Modules
-	if e := ms.entryCache[n]; e != nil {
+
+	// Protect the entryCache map from concurrent access.
+	ms.entryCacheMu.RLock()
+	e = ms.entryCache[n]
+	ms.entryCacheMu.RUnlock()
+	if e != nil {
 		return e
 	}
 	defer func() {
+		ms.entryCacheMu.Lock()
 		ms.entryCache[n] = e
+		ms.entryCacheMu.Unlock()
 	}()
 
 	// Copy in the extensions from our Node, if any.

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -559,18 +559,11 @@ func ToEntry(n Node) (e *Entry) {
 		}
 	}
 	ms := RootNode(n).Modules
-
-	// Protect the entryCache map from concurrent access.
-	ms.entryCacheMu.RLock()
-	e = ms.entryCache[n]
-	ms.entryCacheMu.RUnlock()
-	if e != nil {
+	if e := ms.getEntryCache(n); e != nil {
 		return e
 	}
 	defer func() {
-		ms.entryCacheMu.Lock()
-		ms.entryCache[n] = e
-		ms.entryCacheMu.Unlock()
+		ms.setEntryCache(n, e)
 	}()
 
 	// Copy in the extensions from our Node, if any.


### PR DESCRIPTION
If `ToEntry()` is called concurrently after `entryCache` is cleared with `ClearEntryCache()`, then it is possible for a panic to occur as `entryCache` is being concurrently read/written.

Fixes #261