### PR TITLE
adding must substatements to RPC input/output substatements -- rfc7950

### DIFF
--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -689,7 +689,7 @@ func (s *RPC) Exts() []*Statement     { return s.Extensions }
 func (s *RPC) Groupings() []*Grouping { return s.Grouping }
 func (s *RPC) Typedefs() []*Typedef   { return s.Typedef }
 
-// An Input is defined in: http://tools.ietf.org/html/rfc6020#section-7.13.2
+// An Input is defined in: http://tools.ietf.org/html/rfc7950#section-7.14.2
 type Input struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -704,6 +704,7 @@ type Input struct {
 	Leaf      []*Leaf      `yang:"leaf"`
 	LeafList  []*LeafList  `yang:"leaf-list"`
 	List      []*List      `yang:"list"`
+	Must      []*Must      `yang:"must"`
 	Typedef   []*Typedef   `yang:"typedef"`
 	Uses      []*Uses      `yang:"uses"`
 }
@@ -716,7 +717,7 @@ func (s *Input) Exts() []*Statement     { return s.Extensions }
 func (s *Input) Groupings() []*Grouping { return s.Grouping }
 func (s *Input) Typedefs() []*Typedef   { return s.Typedef }
 
-// An Output is defined in: http://tools.ietf.org/html/rfc6020#section-7.13.3
+// An Output is defined in: http://tools.ietf.org/html/rfc7950#section-7.14.3
 type Output struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -731,6 +732,7 @@ type Output struct {
 	Leaf      []*Leaf      `yang:"leaf"`
 	LeafList  []*LeafList  `yang:"leaf-list"`
 	List      []*List      `yang:"list"`
+	Must      []*Must      `yang:"must"`
 	Typedef   []*Typedef   `yang:"typedef"`
 	Uses      []*Uses      `yang:"uses"`
 }


### PR DESCRIPTION
Hi @wenovus and @robshakir 

Adding must substatement support on the RPC's input/output substatements as per http://tools.ietf.org/html/rfc7950#section-7.14.2 and http://tools.ietf.org/html/rfc7950#section-7.14.3
and updated RFC references in code.

Considering there were earlier yang1.1 substatements already present in the struct, I've added the only missing one.
I did not find any specific test cases of combinations in this specific yang path, as I did not find any similar test cases on the RPC statement. Happy to define some if you think this would be necessary.