### PR TITLE
Implement processing of refine statements, choice shorthand fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tags
+.idea
+.DS_Store
+

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -478,6 +478,7 @@ func (s *List) Groupings() []*Grouping { return s.Grouping }
 func (s *List) Typedefs() []*Typedef   { return s.Typedef }
 
 // A Choice is defined in: http://tools.ietf.org/html/rfc6020#section-7.9
+// for yang 1.1: https://datatracker.ietf.org/doc/html/rfc7950#section-7.9
 type Choice struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -487,6 +488,7 @@ type Choice struct {
 	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Case        []*Case      `yang:"case"`
+	Choice      []*Choice    `yang:"choice"`
 	Config      *Value       `yang:"config"`
 	Container   []*Container `yang:"container"`
 	Default     *Value       `yang:"default"`

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -648,7 +648,7 @@ type Refine struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
-	Default     *Value   `yang:"default"`
+	Defaults    []*Value `yang:"default"`
 	Description *Value   `yang:"description"`
 	IfFeature   []*Value `yang:"if-feature"`
 	Reference   *Value   `yang:"reference"`

--- a/testdata/base.yang
+++ b/testdata/base.yang
@@ -18,6 +18,8 @@ module base {
   prefix "base";
 
   include sub;
+  include refine-tests;
+  include presence-tests;
   import other {
     prefix bother;
   }

--- a/testdata/presence-tests.yang
+++ b/testdata/presence-tests.yang
@@ -1,0 +1,22 @@
+submodule presence-tests {
+  belongs-to base { prefix "sbase"; }
+
+  // sample presence
+  container presence-example-container {
+    presence "the presence of this container means something";
+  }
+
+  grouping grouping-no-presence {
+    container container-no-presence {}
+  }
+
+  container container-with-presence {
+    uses grouping-no-presence {
+        refine container-no-presence {
+            presence "this presence was added with a refine";
+        }
+    }
+  }
+
+
+}

--- a/testdata/refine-tests.yang
+++ b/testdata/refine-tests.yang
@@ -1,0 +1,48 @@
+submodule refine-tests {
+  belongs-to base { prefix "sbase"; }
+  grouping refine-sub-group {
+    leaf refine-sub-group-leaf {
+        type string;
+        default "initial-default";
+        }
+  }
+
+  // sample refine description
+  container refine-description {
+    uses refine-sub-group {
+      refine "refine-sub-group-leaf" {
+        description "new refined description";
+      }
+    }
+  }
+
+  // sample refine leaf default
+  container refine-default {
+    uses refine-sub-group {
+      refine refine-sub-group-leaf {
+        default "refined-default-string";
+      }
+    }
+  }
+
+  grouping fruit-bowl {
+    description
+      "A bowl with a few pieces of fruit by default.";
+    leaf-list fruit {
+      type string;
+      default "apple";
+      default "banana";
+    }
+  }
+
+  // sample refine leaf-list defaults
+  container exotic-bowl {
+    uses fruit-bowl {
+      refine fruit {
+        default "mango";
+        default "papaya";
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR implements the logic to process parsed refine statements according to the Yang 1.1 RFC.
It also implements a fix for choice cases, where the case statement is not present (allowed as per RFC). It does this by inserting the case automatically, such that a choice always has a case and no shorthand is used. This is important as paths are defined as if there is always a case node in the tree, even if it is missing in the schema.