### PR TITLE
Implement yangentry.ParseWithOptions method to allow specifying options for YANG module parsing

### DIFF
--- a/pkg/yangentry/build_yang.go
+++ b/pkg/yangentry/build_yang.go
@@ -28,8 +28,24 @@ import (
 // parsed top level modules. It also returns a list of errors encountered while
 // parsing, if any.
 func Parse(yangfiles, path []string) (map[string]*yang.Entry, []error) {
-	ms := yang.NewModules()
+	return parse(yangfiles, path, yang.NewModules())
+}
 
+// ParseWithOptions takes a list of either module/submodule names or .yang file
+// paths, a list of include paths, and a set of parse options. It configures the
+// yang parser with the specified parse options and runs it on the YANG
+// files by searching for them in the include paths or in the current
+// directory, returning a slice of yang.Entry pointers which represent the
+// parsed top level modules. It also returns a list of errors encountered while
+// parsing, if any.
+func ParseWithOptions(yangfiles, path []string, parseOptions yang.Options) (map[string]*yang.Entry, []error) {
+	ms := yang.NewModules()
+	ms.ParseOptions = parseOptions
+
+	return parse(yangfiles, path, ms)
+}
+
+func parse(yangfiles, path []string, ms *yang.Modules) (map[string]*yang.Entry, []error) {
 	for _, p := range path {
 		ms.AddPath(fmt.Sprintf("%s/...", p))
 	}

--- a/pkg/yangentry/testdata/05-circular-main.yang
+++ b/pkg/yangentry/testdata/05-circular-main.yang
@@ -1,0 +1,12 @@
+module circular-main {
+    yang-version "1.1";
+
+    namespace "urn:test:circular:main";
+
+    prefix "main";
+
+    include circular-sub-one;
+    include circular-sub-two;
+
+    revision "2025-02-15";
+}

--- a/pkg/yangentry/testdata/subdir/circular-sub-one.yang
+++ b/pkg/yangentry/testdata/subdir/circular-sub-one.yang
@@ -1,0 +1,9 @@
+submodule circular-sub-one {
+    yang-version "1.1";
+
+    belongs-to circular-main { prefix "main"; }
+
+    include circular-sub-two;
+
+    revision "2025-02-15";
+}

--- a/pkg/yangentry/testdata/subdir/circular-sub-two.yang
+++ b/pkg/yangentry/testdata/subdir/circular-sub-two.yang
@@ -1,0 +1,9 @@
+submodule circular-sub-two {
+    yang-version "1.1";
+
+    belongs-to circular-main { prefix "main"; }
+
+    include circular-sub-one;
+
+    revision "2025-02-15";
+}


### PR DESCRIPTION
This PR implements the `yangentry.ParseWithOptions` method that takes a `ParseOptions` parameter and uses it to configure the `Modules` object created with `yang.NewModules()`. See issue #288 for additional context.

Closes #288.

_**Legal Notice**:  This code is a Contribution to the OpenConfig goyang sub-project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind._