### PR TITLE
Allow for deviate add of extensions

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1194,6 +1194,10 @@ func (e *Entry) ApplyDeviate(deviateOpts ...DeviateOpt) []error {
 						deviatedNode.Extra["must"] = append(deviatedNode.Extra["must"], musts...)
 					}
 
+					if len(devSpec.Exts) > 0 {
+						deviatedNode.Exts = append(deviatedNode.Exts, devSpec.Exts...)
+					}
+
 				case DeviationNotSupported:
 					dp := deviatedNode.Parent
 					if dp == nil {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -3658,6 +3658,43 @@ func TestDeviation(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		desc: "deviate add extension",
+		inFiles: map[string]string{
+			"module": `
+			module test-deviate-add-extension {
+				prefix "a";
+				namespace "urn:a";
+
+				container foo {
+					leaf bar {
+						type string;
+						ext:extension1 "extension 1";
+					}
+				}
+				deviation /foo/bar {
+					deviate add {
+						ext:extension2;
+						ext:extension3 "extension 3";
+					}
+				}
+			}`,
+		},
+		wants: map[string][]deviationTest{
+			"test-deviate-add-extension": {
+				{
+					path: "/a:foo/a:bar",
+					entry: &Entry{
+						Name: "mode",
+						Exts: []*Statement{
+							{Keyword: "ext:extension1", HasArgument: true, Argument: "extension 1"},
+							{Keyword: "ext:extension2"},
+							{Keyword: "ext:extension3", HasArgument: true, Argument: "extension 3"},
+						},
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tt := range tests {
@@ -3768,6 +3805,11 @@ func TestDeviation(t *testing.T) {
 					MustDiff := cmp.Diff(wantMust, gotMust)
 					if MustDiff != "" {
 						t.Errorf("Must deviation mismatch (-want +got):\n%s", MustDiff)
+					}
+
+					if extsDiff := cmp.Diff(want.entry.Exts, got.Exts,
+						cmpopts.IgnoreUnexported(Statement{})); extsDiff != "" {
+						t.Errorf("Exts mismatch (-want +got):\n%s", extsDiff)
 					}
 				}
 			}


### PR DESCRIPTION
For example:

```
  deviation "/a:foo/b:bar" {
    deviate add {
      ext:my-extension;
    }
  }
```
will add the extension `ext:my-extension` to the `e.Exts` field to the `/a:foo/b:bar` path in the AST.