### PR TITLE
add must to input and output substatement

### DIFF
--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1804,13 +1804,15 @@ func getEntry(root *Entry, path []string) *Entry {
 
 func TestActionRPC(t *testing.T) {
 	tests := []struct {
-		name          string
-		inModule      string
-		operationPath []string
-		wantNodeKind  string
-		wantError     string
-		noInput       bool
-		noOutput      bool
+		name           string
+		inModule       string
+		operationPath  []string
+		wantNodeKind   string
+		wantError      string
+		noInput        bool
+		noOutput       bool
+		wantInputMust  []string
+		wantOutputMust []string
 	}{
 		{
 			name:          "test action in container",
@@ -1990,23 +1992,24 @@ func TestActionRPC(t *testing.T) {
 }`,
 		},
 		{
-			name:          "input-output rpc with must",
-			wantNodeKind:  "rpc",
-			operationPath: []string{"operation"},
+			name:           "input-output rpc with must",
+			wantNodeKind:   "rpc",
+			operationPath:  []string{"operation"},
+			wantInputMust:  []string{"false()"},
+			wantOutputMust: []string{"true()", "b"},
 			inModule: `module test {
   namespace "urn:test";
   prefix "test";
   rpc operation {
     description "rpc";
     input {
-      must "false" {
+      must "false()" {
         error-message "imposible";
       }
     }
     output {
-      must "false" {
-        error-message "imposible";
-      }
+      must "true()";
+	  must "b";
     }
   }
 }`,
@@ -2048,7 +2051,33 @@ func TestActionRPC(t *testing.T) {
 		} else if !tt.noOutput && e.RPC.Output == nil {
 			t.Errorf("%s: RPCEntry has nil Output, want: non-nil. Entry: %#v", tt.name, e.RPC)
 		}
+		if e.RPC != nil {
+			if got := mustExprs(t, tt.name, e.RPC.Input); !reflect.DeepEqual(got, tt.wantInputMust) {
+				t.Errorf("%s: input must expressions: got %v, want %v", tt.name, got, tt.wantInputMust)
+			}
+			if got := mustExprs(t, tt.name, e.RPC.Output); !reflect.DeepEqual(got, tt.wantOutputMust) {
+				t.Errorf("%s: output must expressions: got %v, want %v", tt.name, got, tt.wantOutputMust)
+			}
+		}
+
 	}
+}
+
+func mustExprs(t *testing.T, name string, e *Entry) []string {
+	t.Helper()
+	if e == nil {
+		return nil
+	}
+	var exprs []string
+	for _, x := range e.Extra["must"] {
+		m, ok := x.(*Must)
+		if !ok {
+			t.Errorf("%s: Extra[\"must\"] contains %T, want *Must", name, x)
+			continue
+		}
+		exprs = append(exprs, m.Name)
+	}
+	return exprs
 }
 
 var testIfFeatureModules = []struct {

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -1989,6 +1989,28 @@ func TestActionRPC(t *testing.T) {
   }
 }`,
 		},
+		{
+			name:          "input-output rpc with must",
+			wantNodeKind:  "rpc",
+			operationPath: []string{"operation"},
+			inModule: `module test {
+  namespace "urn:test";
+  prefix "test";
+  rpc operation {
+    description "rpc";
+    input {
+      must "false" {
+        error-message "imposible";
+      }
+    }
+    output {
+      must "false" {
+        error-message "imposible";
+      }
+    }
+  }
+}`,
+		},
 	}
 	for _, tt := range tests {
 		ms := NewModules()

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -689,7 +689,7 @@ func (s *RPC) Exts() []*Statement     { return s.Extensions }
 func (s *RPC) Groupings() []*Grouping { return s.Grouping }
 func (s *RPC) Typedefs() []*Typedef   { return s.Typedef }
 
-// An Input is defined in: http://tools.ietf.org/html/rfc6020#section-7.13.2
+// An Input is defined in: http://tools.ietf.org/html/rfc7950#section-7.14.2
 type Input struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -704,6 +704,7 @@ type Input struct {
 	Leaf      []*Leaf      `yang:"leaf"`
 	LeafList  []*LeafList  `yang:"leaf-list"`
 	List      []*List      `yang:"list"`
+	Must      []*Must      `yang:"must"`
 	Typedef   []*Typedef   `yang:"typedef"`
 	Uses      []*Uses      `yang:"uses"`
 }
@@ -716,7 +717,7 @@ func (s *Input) Exts() []*Statement     { return s.Extensions }
 func (s *Input) Groupings() []*Grouping { return s.Grouping }
 func (s *Input) Typedefs() []*Typedef   { return s.Typedef }
 
-// An Output is defined in: http://tools.ietf.org/html/rfc6020#section-7.13.3
+// An Output is defined in: http://tools.ietf.org/html/rfc7950#section-7.14.3
 type Output struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -731,6 +732,7 @@ type Output struct {
 	Leaf      []*Leaf      `yang:"leaf"`
 	LeafList  []*LeafList  `yang:"leaf-list"`
 	List      []*List      `yang:"list"`
+	Must      []*Must      `yang:"must"`
 	Typedef   []*Typedef   `yang:"typedef"`
 	Uses      []*Uses      `yang:"uses"`
 }


### PR DESCRIPTION
Adding support for must in input and output substatement as defined in https://datatracker.ietf.org/doc/html/rfc7950#section-7.14.2 and https://datatracker.ietf.org/doc/html/rfc7950#section-7.14.3

As opposed to #270, I've added test so that this change can be merged. 